### PR TITLE
chore(deps): migrate to zod 4

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,7 @@
     "@fastify/static": "^10.1.2",
     "bcryptjs": "^3.0.2",
     "fastify": "^5.10.0",
-    "zod": "^3.25.0"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^24.0.0",

--- a/backend/src/routes/profiles.ts
+++ b/backend/src/routes/profiles.ts
@@ -9,7 +9,7 @@ const createSchema = z.object({
     .min(2)
     .max(30)
     .regex(/^[A-Za-z0-9_\s-]+$/, 'Имя: латиница, цифры, пробел, - и _'),
-  config: z.record(z.unknown()),
+  config: z.record(z.string(), z.unknown()),
 })
 
 const updateSchema = z.object({
@@ -19,7 +19,7 @@ const updateSchema = z.object({
     .max(30)
     .regex(/^[A-Za-z0-9_\s-]+$/, 'Имя: латиница, цифры, пробел, - и _')
     .optional(),
-  config: z.record(z.unknown()).optional(),
+  config: z.record(z.string(), z.unknown()).optional(),
   expectedUpdatedAt: z.string().min(1),
 })
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,7 +24,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-router": "^8.3.0",
-    "zod": "^3.25.0",
+    "zod": "^4.4.3",
     "zustand": "^5.0.5"
   },
   "devDependencies": {

--- a/frontend/src/entities/xray/dns.ts
+++ b/frontend/src/entities/xray/dns.ts
@@ -16,7 +16,7 @@ export const DnsServerSchema = z.union([z.string(), DnsServerObjectSchema])
 export const DnsSchema = z
   .object({
     servers: z.array(DnsServerSchema).optional(),
-    hosts: z.record(z.union([z.string(), z.array(z.string())])).optional(),
+    hosts: z.record(z.string(), z.union([z.string(), z.array(z.string())])).optional(),
     clientIp: z.string().optional(),
     queryStrategy: z.string().optional(),
     tag: z.string().optional(),

--- a/frontend/src/entities/xray/inbounds.ts
+++ b/frontend/src/entities/xray/inbounds.ts
@@ -58,10 +58,10 @@ export const ShadowsocksInboundSettingsSchema = z
 
 export const InboundSchema = z
   .object({
-    tag: z.string({ required_error: 'У inbound должен быть tag' }),
+    tag: z.string({ error: 'У inbound должен быть tag' }),
     port: z.union([z.number(), z.string()]).optional(),
     listen: z.string().optional(),
-    protocol: z.string({ required_error: 'У inbound должен быть protocol' }),
+    protocol: z.string({ error: 'У inbound должен быть protocol' }),
     settings: obj().optional(),
     streamSettings: StreamSettingsSchema.optional(),
     sniffing: SniffingSchema.optional(),

--- a/frontend/src/entities/xray/outbounds.ts
+++ b/frontend/src/entities/xray/outbounds.ts
@@ -110,8 +110,8 @@ const OUTBOUND_SETTINGS_BY_PROTOCOL: Record<string, z.ZodTypeAny> = {
 
 export const OutboundSchema = z
   .object({
-    tag: z.string({ required_error: 'У outbound должен быть tag' }),
-    protocol: z.string({ required_error: 'У outbound должен быть protocol' }),
+    tag: z.string({ error: 'У outbound должен быть tag' }),
+    protocol: z.string({ error: 'У outbound должен быть protocol' }),
     settings: obj().optional(),
     streamSettings: StreamSettingsSchema.optional(),
     proxySettings: obj().optional(),

--- a/frontend/src/entities/xray/stream.ts
+++ b/frontend/src/entities/xray/stream.ts
@@ -53,7 +53,7 @@ export const WsSettingsSchema = z
   .object({
     path: z.string().optional(),
     host: z.string().optional(),
-    headers: z.record(z.string()).optional(),
+    headers: z.record(z.string(), z.string()).optional(),
     heartbeatPeriod: z.number().optional(),
     acceptProxyProtocol: z.boolean().optional(),
   })
@@ -71,7 +71,7 @@ export const HttpupgradeSettingsSchema = z
   .object({
     path: z.string().optional(),
     host: z.string().optional(),
-    headers: z.record(z.string()).optional(),
+    headers: z.record(z.string(), z.string()).optional(),
     acceptProxyProtocol: z.boolean().optional(),
   })
   .passthrough()

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@fastify/static": "^10.1.2",
         "bcryptjs": "^3.0.2",
         "fastify": "^5.10.0",
-        "zod": "^3.25.0"
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@types/node": "^24.0.0",
@@ -44,7 +44,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-router": "^8.3.0",
-        "zod": "^3.25.0",
+        "zod": "^4.4.3",
         "zustand": "^5.0.5"
       },
       "devDependencies": {
@@ -5632,9 +5632,9 @@
       "license": "ISC"
     },
     "node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"


### PR DESCRIPTION
Закрывает #10 — Dependabot предложил zod 4.4.3, но мажор не собирался без правок кода. Здесь бамп вместе с миграцией.

## Что ломалось

**`z.record` потерял одноаргументную форму** — нужен явный тип ключа (5 мест): `backend/src/routes/profiles.ts` (×2), `entities/xray/dns.ts` (`hosts`), `entities/xray/stream.ts` (заголовки ws и httpupgrade). В zod 3 ключ и так подразумевался строкой, поведение не меняется.

**`required_error` заменён единым `error`** — zod 4 схлопнул `required_error` и `invalid_type_error` в один параметр (4 места: `tag` и `protocol` у `InboundSchema` и `OutboundSchema`). Русские тексты сообщений сохранены.

## Что проверено

Локально: `typecheck` обоих workspace — 0 ошибок, backend 210 тестов, frontend 672 теста, все зелёные.

54 вызова `.passthrough()`, на которых держится round-trip неизвестных полей Xray-конфига, в zod 4 помечены deprecated, но работают без изменений — тесты round-trip это подтверждают. Замена на `z.looseObject()` — отдельная уборка, не смешиваю с обновлением версии.

🤖 Generated with [Claude Code](https://claude.com/claude-code)