### PR TITLE
ci: scan for secrets with gitleaks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,5 +36,13 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    # Мажор базового образа — не автоматическая правка: node зашит ещё в
+    # --target node24 у tsup и в node-version у CI, а прыгать на релиз до его
+    # перехода в LTS проект не хочет. Обновляем осознанно, все места разом.
+    ignore:
+      - dependency-name: node
+        update-types: [version-update:semver-major]
+      - dependency-name: alpine
+        update-types: [version-update:semver-major]
     commit-message:
       prefix: chore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,3 +74,40 @@ jobs:
           name: playwright-report
           path: frontend/playwright-report/
           retention-days: 7
+
+  secrets:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      # Полная история: секрет, добавленный и снесённый следующим коммитом,
+      # остаётся в репозитории и должен находиться.
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      # Официальный gitleaks-action лежит под коммерческой EULA, сам gitleaks —
+      # под MIT. Ставим бинарь релиза с проверкой контрольной суммы, как ядро
+      # Xray в Dockerfile; при смене версии двигать оба значения.
+      - name: Install gitleaks
+        env:
+          GITLEAKS_VERSION: 8.30.1
+          GITLEAKS_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
+        run: |
+          curl -fsSL -o gitleaks.tar.gz \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          echo "${GITLEAKS_SHA256}  gitleaks.tar.gz" | sha256sum -c -
+          tar -xzf gitleaks.tar.gz gitleaks
+
+      # --redact обязателен: логи публичного репозитория читает кто угодно.
+      - name: Scan history
+        run: ./gitleaks git . --config .gitleaks.toml --redact --no-banner
+
+      - name: .env и data/ не должны попадать под версионный контроль
+        run: |
+          tracked=$(git ls-files -- .env 'data/**')
+          if [ -n "$tracked" ]; then
+            echo "::error::Под версионным контролем оказались файлы с секретами:"
+            echo "$tracked"
+            exit 1
+          fi

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,45 @@
+title = "xray-ui-editor"
+
+# Стандартный набор правил gitleaks плюс три своих. Секреты этого проекта не
+# подпадают ни под один провайдерский паттерн, а бесплатный secret scanning
+# GitHub на публичных репозиториях ловит только провайдерские: токен панели и
+# секрет сессии он пропустит.
+[extend]
+useDefault = true
+# JFrog в проекте не используется, а его правило срабатывает на sha256 архива
+# с ядром Xray (ARG XRAY_SHA256 в Dockerfile) — те же 64 hex-символа. Хэш
+# меняется при каждом обновлении ядра, поэтому исключение по значению пришлось
+# бы править каждый раз.
+disabledRules = ["jfrog-identity-token"]
+
+[allowlist]
+description = "Заведомо фальшивые значения из фикстур тестов и планов в docs/"
+regexTarget = "match"
+regexes = ['''0123456789abcdef0123456789abcdef''', '''super-secret-1''']
+
+[[rules]]
+id = "remnawave-panel-token"
+description = "Токен API панели Remnawave"
+regex = '''(?i)REMNAWAVE_TOKEN\s*[=:]\s*["']?[A-Za-z0-9._\-]{16,}'''
+tags = ["token", "remnawave"]
+  [rules.allowlist]
+  paths = ['''^\.env\.example$''']
+
+[[rules]]
+id = "app-session-secret"
+description = "Секрет подписи сессионных cookie"
+regex = '''(?i)SESSION_SECRET\s*[=:]\s*["']?[A-Za-z0-9+/=_\-]{24,}'''
+tags = ["secret"]
+  [rules.allowlist]
+  paths = ['''^\.env\.example$''']
+
+[[rules]]
+id = "app-password"
+description = "Пароль входа в редактор (открытый текст или bcrypt-хэш)"
+regex = '''(?i)APP_PASSWORD\s*[=:]\s*["']?\S{8,}'''
+tags = ["password"]
+  [rules.allowlist]
+  # README и .env.example разбирают на примерах гейтчу с "$" в bcrypt-хэше,
+  # а config.ts объявляет поле zod-схемой — это описание, а не значение.
+  paths = ['''^\.env\.example$''', '''^README\.md$''', '''^docs/''']
+  regexes = ['''z\.string''']


### PR DESCRIPTION
Закрывает пробел, оставшийся после того, как выяснилось, что validity checks и non-provider patterns требуют GitHub Secret Protection (продаётся с плана Team). Бесплатный secret scanning ловит только провайдерские паттерны, а `REMNAWAVE_TOKEN` и `SESSION_SECRET` не подпадают ни под один — push protection пропустила бы их молча.

## Почему бинарь, а не готовый экшен

Официальный `gitleaks/gitleaks-action` распространяется под коммерческой EULA (бесплатен для публичных репозиториев, но это всё же проприетарная обёртка). Сам gitleaks — MIT. Джоба ставит бинарь релиза и сверяет sha256 — тем же приёмом, которым в `Dockerfile` пинится ядро Xray. При смене версии двигать оба значения, как и там.

## Что в конфиге

Стандартный набор правил плюс три своих — `REMNAWAVE_TOKEN`, `SESSION_SECRET`, `APP_PASSWORD`.

Отключено правило `jfrog-identity-token`: оно срабатывает на `ARG XRAY_SHA256` в `Dockerfile` — те же 64 hex-символа, что и у токена, который оно ищет. Хэш меняется при каждом обновлении ядра, поэтому исключение по значению пришлось бы править каждый раз.

Фикстуры, на которых спотыкались стандартные правила (`0123456789abcdef…`, `super-secret-1`), исключены **по значению, а не по пути** — каталоги тестов остаются под сканированием, и настоящий секрет, вставленный в тест, будет найден.

## Проверено локально

| Сценарий | Результат |
|---|---|
| Вся история репозитория, 236 коммитов | находок нет |
| Файл-проба с реалистичными значениями | сработали все три правила |

Первый прогон дал 7 находок, все ложные — они и определили содержимое конфига.

## Вторая проверка в джобе

`git ls-files` на `.env` и `data/**`: они в `.gitignore`, но `.gitignore` не мешает добавить файл через `git add -f`. Бэкапы в `data/` — это приватные ключи Reality и WARP, цена ошибки здесь та же, что у утёкшего `.env`.

## Заодно

Dependabot больше не предлагает мажоры базовых образов (`node`, `alpine`). Закрытие #6 — это решение про сроки LTS: Node 26 станет LTS в октябре, а версия зашита ещё в `--target node24` у tsup и в `node-version` у CI. Вернёмся к этому одной задачей на три места.

## После мержа

Джоба называется `gitleaks` — если хочешь, чтобы она блокировала мерж, добавь её в обязательные чеки ruleset рядом с остальными.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
