### PR TITLE
fix(backend): address the CodeQL findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,11 @@ npm run e2e -w frontend                   # Playwright e2e (перед перв�
 - `server.ts` — `buildServer(config, deps)`: сборка приложения. Через `deps` инжектятся `RemnawavePort` и `BackupService` — так тесты подменяют панель стабом (`test/stub-remnawave.ts`).
 - `remnawave/client.ts` — `RemnawaveClient` (реализация `RemnawavePort`), все ошибки панели заворачиваются в `RemnawaveError` и превращаются глобальным error handler'ом в JSON-ответы с исходным статусом.
 - `routes/profiles.ts` — ключевой флоу сохранения: `PATCH /api/profiles/:uuid` требует `expectedUpdatedAt`; при расхождении — `409` с актуальным профилем (оптимистическая блокировка). Перед каждым обновлением текущая версия пишется в бэкап (`backups/service.ts`, каталог `DATA_DIR/backups/<uuid>/`).
-- `auth/*` — вход по паролю (`APP_PASSWORD` — plaintext или bcrypt-хэш), подписанная httpOnly-cookie, rate-limit на логин, guard закрывает все `/api/*` кроме auth/health.
+- `auth/*` — вход по паролю, подписанная httpOnly-cookie, guard закрывает все `/api/*` кроме
+  auth/health. В `.env` `APP_PASSWORD` может быть и открытым текстом, и bcrypt-хэшем, но
+  `loadConfig` хэширует открытый на старте — в `AppConfig.appPassword` всегда лежит хэш, и
+  `verifyPassword` знает единственный формат. Rate-limit двухуровневый: 5 попыток в минуту на
+  логине и глобальные 600 запросов в минуту на остальное.
 - `xray/*` — проверка конфига ядром: `dummyClient.ts` подставляет фиктивного пользователя
   (профили панели хранятся с `clients: []`), `service.ts` запускает `xray run -test` с
   `XRAY_LOCATION_ASSET` на geo-базы из `DATA_DIR`, `parseOutput.ts` переводит цепочки ошибок ядра

--- a/backend/src/auth/password.ts
+++ b/backend/src/auth/password.ts
@@ -1,11 +1,9 @@
 import bcrypt from 'bcryptjs'
-import { createHash, timingSafeEqual } from 'node:crypto'
 
+/**
+ * `stored` — всегда bcrypt-хэш: открытый пароль из `.env` превращает в хэш
+ * `loadConfig` на старте, поэтому здесь один формат и одна ветка сравнения.
+ */
 export async function verifyPassword(candidate: string, stored: string): Promise<boolean> {
-  if (stored.startsWith('$2')) {
-    return bcrypt.compare(candidate, stored)
-  }
-  const a = createHash('sha256').update(candidate).digest()
-  const b = createHash('sha256').update(stored).digest()
-  return timingSafeEqual(a, b)
+  return bcrypt.compare(candidate, stored)
 }

--- a/backend/src/config.ts
+++ b/backend/src/config.ts
@@ -1,3 +1,4 @@
+import bcrypt from 'bcryptjs'
 import { z } from 'zod'
 
 const envSchema = z.object({
@@ -33,6 +34,17 @@ export interface AppConfig {
   xrayBin: string
 }
 
+/**
+ * Открытый пароль хэшируется один раз на старте: дальше по приложению (и в
+ * сообщения об ошибках) уезжает уже хэш, а проверка входа знает единственный
+ * формат. Для оператора ничего не меняется — в `.env` по-прежнему кладётся
+ * либо открытый текст, либо готовый хэш.
+ */
+function toPasswordHash(value: string): string {
+  if (value.startsWith('$2')) return value
+  return bcrypt.hashSync(value, 12)
+}
+
 export function loadConfig(env: NodeJS.ProcessEnv = process.env): AppConfig {
   const parsed = envSchema.safeParse(env)
   if (!parsed.success) {
@@ -55,7 +67,7 @@ export function loadConfig(env: NodeJS.ProcessEnv = process.env): AppConfig {
     port: e.PORT,
     remnawaveUrl: e.REMNAWAVE_URL.replace(/\/+$/, ''),
     remnawaveToken: e.REMNAWAVE_TOKEN,
-    appPassword: e.APP_PASSWORD,
+    appPassword: toPasswordHash(e.APP_PASSWORD),
     sessionSecret: e.SESSION_SECRET,
     dataDir: e.DATA_DIR,
     staticDir: e.STATIC_DIR,

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -47,8 +47,14 @@ export async function buildServer(
   const app = Fastify({ logger: process.env.NODE_ENV !== 'test' })
 
   await app.register(cookie, { secret: config.sessionSecret })
+  // Глобальный потолок — защита закрытых ручек от перебора cookie и от того,
+  // что один клиент займёт собой весь сервер. Он заведомо выше живого
+  // сценария (загрузка SPA — десятки запросов, вьюер geo-баз листает
+  // страницами), а жёсткий лимит на логине задан отдельно в его роуте.
   await app.register(rateLimit, {
-    global: false,
+    global: true,
+    max: 600,
+    timeWindow: '1 minute',
     errorResponseBuilder: (_req, context) => ({
       message: `Слишком много попыток. Повторите через ${context.after}`,
       statusCode: 429,

--- a/backend/test/config.test.ts
+++ b/backend/test/config.test.ts
@@ -1,3 +1,4 @@
+import bcrypt from 'bcryptjs'
 import { describe, expect, it } from 'vitest'
 import { loadConfig } from '../src/config.js'
 
@@ -39,6 +40,13 @@ describe('loadConfig', () => {
   it('принимает целый bcrypt-хэш длиной 60', () => {
     const intact = '$2b$12$C6UzMDM.H6dfI/f/IKcEeO7ZBpDvhpVghUlmxvIgGmXcSl7dcqrqq'
     expect(loadConfig({ ...validEnv, APP_PASSWORD: intact }).appPassword).toBe(intact)
+  })
+
+  it('открытый пароль превращается в bcrypt-хэш, а не едет дальше как есть', () => {
+    const { appPassword } = loadConfig(validEnv)
+    expect(appPassword).not.toBe(validEnv.APP_PASSWORD)
+    expect(appPassword.startsWith('$2')).toBe(true)
+    expect(bcrypt.compareSync(validEnv.APP_PASSWORD, appPassword)).toBe(true)
   })
 
   it('XRAY_BIN по умолчанию — xray в PATH', () => {

--- a/backend/test/helpers.ts
+++ b/backend/test/helpers.ts
@@ -1,17 +1,21 @@
 import { mkdtempSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import bcrypt from 'bcryptjs'
 import type { FastifyInstance } from 'fastify'
 import type { AppConfig } from '../src/config.js'
 
 export const TEST_PASSWORD = 'test-password-123'
+// AppConfig.appPassword всегда хранит bcrypt-хэш (см. loadConfig). Cost 4 —
+// чтобы каждый makeTestConfig не стоил четверти секунды.
+const TEST_PASSWORD_HASH = bcrypt.hashSync(TEST_PASSWORD, 4)
 
 export function makeTestConfig(overrides: Partial<AppConfig> = {}): AppConfig {
   return {
     port: 0,
     remnawaveUrl: 'http://panel.test',
     remnawaveToken: 'test-token',
-    appPassword: TEST_PASSWORD,
+    appPassword: TEST_PASSWORD_HASH,
     sessionSecret: '0123456789abcdef0123456789abcdef',
     dataDir: mkdtempSync(join(tmpdir(), 'xui-data-')),
     staticDir: join(process.cwd(), 'public'),

--- a/backend/test/password.test.ts
+++ b/backend/test/password.test.ts
@@ -3,14 +3,15 @@ import bcrypt from 'bcryptjs'
 import { verifyPassword } from '../src/auth/password.js'
 
 describe('verifyPassword', () => {
-  it('сравнивает открытый пароль', async () => {
-    expect(await verifyPassword('secret-123', 'secret-123')).toBe(true)
-    expect(await verifyPassword('wrong', 'secret-123')).toBe(false)
-  })
-
   it('поддерживает bcrypt-хэш', async () => {
     const hash = await bcrypt.hash('secret-123', 8)
     expect(await verifyPassword('secret-123', hash)).toBe(true)
     expect(await verifyPassword('wrong', hash)).toBe(false)
+  })
+
+  it('открытый пароль в stored не пускает внутрь', async () => {
+    // loadConfig отдаёт в конфиг только хэш, поэтому сравнение двух открытых
+    // строк — это признак ошибки сборки конфига, а не успешный вход.
+    expect(await verifyPassword('secret-123', 'secret-123')).toBe(false)
   })
 })


### PR DESCRIPTION
Разбор шести открытых алертов CodeQL. Три оказались настоящими и исправлены здесь, три — ложные или намеренные, их закрываю в интерфейсе Security с обоснованием.

## Исправлено

**`js/insufficient-password-hash` (2 алерта, `auth/password.ts:8,9`).** `verifyPassword` считал sha256 от кандидата и от сохранённого значения, чтобы получить буферы равной длины для `timingSafeEqual` — приём корректный, но CodeQL видит быстрый хэш на пути пароля и не может отличить сравнение от хранения.

Вместо того чтобы гасить алерт, убран сам сценарий: `loadConfig` теперь хэширует открытый `APP_PASSWORD` один раз на старте, и в `AppConfig.appPassword` всегда лежит bcrypt-хэш. У `verifyPassword` осталась одна ветка. Для оператора ничего не меняется — в `.env` по-прежнему кладётся либо открытый текст, либо готовый хэш.

Побочный, но не бесполезный эффект: открытый пароль больше не расходится по приложению вместе с объектом конфига.

**`js/missing-rate-limiting` (`auth/guard.ts:7`).** Здесь CodeQL прав по существу. Guard авторизует **все** `/api/*` из `onRequest`-хука, а лимит стоял только на роуте логина: перебор сессионной cookie и обычное затопление закрытых ручек шли без счётчика. Теперь `@fastify/rate-limit` глобальный — 600 запросов в минуту, при том что логин сохраняет свои 5.

Потолок заведомо выше живого сценария: загрузка SPA — это десятки запросов, вьюер geo-баз листает категории страницами.

## Закрываю как ложные

**`js/incomplete-url-substring-sanitization` (`frontend/test/xray-config.test.ts:427`).** `i.parts.includes('example.com')` — это `Array.prototype.includes` по массиву сегментов пути диагностики. Никакого URL здесь нет, проверка домена — тоже: тест ровно про то, что ключ с точкой (`hosts`) не разваливается на сегменты.

**`js/clear-text-logging` (`index.ts:9`).** Taint-анализ ведёт `APP_PASSWORD` в сообщение ошибки, но в сообщение попадает только `.length` — подсказка про интерполяцию `$` в Docker Compose печатает число символов, а не значение. После правки выше в конфиге к этому моменту и вовсе лежит хэш.

**`js/disabling-certificate-validation` (`tools/realityProbe.ts:225`).** `rejectUnauthorized: false` — суть инструмента: проба обязана увидеть и разобрать даже негодный сертификат чужой Reality-цели, иначе она не сможет сказать, годится ли цель. Секреты в это соединение не отправляются, а результат проверки цепочки не теряется — он уходит в вердикт `chain`. Причина закрытия — «не будет исправлено», а не «ложное срабатывание»: сертификат тут действительно не проверяется, и так задумано.

## Проверено

Backend: 211 тестов (было 210 — добавлен на хэширование открытого пароля), typecheck чистый.

`verifyPassword` потерял ветку открытого сравнения, поэтому её тест теперь утверждает обратное: открытый пароль в `stored` внутрь не пускает.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
