### PR TITLE
test(backend): cover the global rate limit

### DIFF
--- a/backend/test/rate-limit.test.ts
+++ b/backend/test/rate-limit.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { buildServer } from '../src/server.js'
+import { loginCookie, makeTestConfig } from './helpers.js'
+
+describe('глобальный rate-limit', () => {
+  it('закрытые ручки отдают заголовки лимита', async () => {
+    const app = await buildServer(makeTestConfig())
+    const cookie = await loginCookie(app)
+    const res = await app.inject({ method: 'GET', url: '/api/auth/me', headers: { cookie } })
+    expect(res.statusCode).toBe(200)
+    expect(String(res.headers['x-ratelimit-limit'])).toBe('600')
+    await app.close()
+  })
+
+  it('после потолка отвечает 429 с русским текстом', async () => {
+    const app = await buildServer(makeTestConfig())
+    let last = await app.inject({ method: 'GET', url: '/health' })
+    for (let i = 0; i < 700 && last.statusCode !== 429; i += 1) {
+      last = await app.inject({ method: 'GET', url: '/health' })
+    }
+    expect(last.statusCode).toBe(429)
+    expect(last.json().message).toMatch(/Слишком много попыток/)
+    await app.close()
+  })
+})


### PR DESCRIPTION
Хвост к #19: глобальный лимит там появился без собственного теста, а `global: true` легко вернуть в `false` последующей правкой и не заметить.

Два теста:
- закрытая ручка отдаёт `x-ratelimit-limit: 600`;
- после потолка приходит 429 с текстом «Слишком много попыток».

Заодно это доказательство, что алерт CodeQL `js/missing-rate-limiting` на `auth/guard.ts` теперь ложный: лимит есть и срабатывает, просто CodeQL не моделирует `@fastify/rate-limit`.

Прогон: 2 теста, 245 мс.

🤖 Generated with [Claude Code](https://claude.com/claude-code)