### PR TITLE
chore(deps): keep @types/node on the runtime major

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,11 @@ updates:
       interval: weekly
       day: monday
     open-pull-requests-limit: 5
+    # Мажор @types/node описывает рантайм, которого у проекта нет: он держится
+    # на Node 24 LTS. Обновляем вместе с базовым образом, а не раньше.
+    ignore:
+      - dependency-name: '@types/node'
+        update-types: [version-update:semver-major]
     # Мелочь — одним PR, мажорные версии приходят по отдельности.
     groups:
       npm-minor-patch:


### PR DESCRIPTION
Закрывает #17.

`@types/node` 26 описывает рантайм, которого у проекта нет — он держится на Node 24 LTS. Это не теория: CI на #17 падает на `backend/src/tools/reality.ts:41` — `KeyObject` перестал приниматься там, где принимался (`error TS2345`).

Мажоры базового образа (`node`, `alpine`) уже закреплены — теперь типы следуют за ним же. Минорные и патч-обновления внутри 24.x продолжают приходить как обычно.

Вернёмся к этому в октябре, когда Node 26 станет LTS: править нужно будет три места разом — `Dockerfile`, `--target node24` у tsup и `node-version` в CI, — и `@types/node` четвёртым.

🤖 Generated with [Claude Code](https://claude.com/claude-code)