### PR TITLE
refactor(frontend): swap passthrough for z.looseObject

### DIFF
--- a/frontend/src/entities/graph/mutations.ts
+++ b/frontend/src/entities/graph/mutations.ts
@@ -72,7 +72,7 @@ function retagInPlace(
   for (const out of config.outbounds ?? []) {
     const sockopt = out.streamSettings?.sockopt
     if (sockopt?.dialerProxy === oldTag) sockopt.dialerProxy = newTag
-    // proxySettings хранится нетипизированным объектом (passthrough)
+    // proxySettings хранится нетипизированным объектом (схема его пропускает)
     const proxy = (out as { proxySettings?: { tag?: string } }).proxySettings
     if (proxy?.tag === oldTag) proxy.tag = newTag
   }

--- a/frontend/src/entities/xray/balancers.ts
+++ b/frontend/src/entities/xray/balancers.ts
@@ -9,20 +9,17 @@ export const BALANCER_STRATEGIES = ['random', 'roundRobin', 'leastPing', 'leastL
 
 // strategy.type — строка, а не z.enum: незнакомая стратегия из чужого конфига должна
 // давать предупреждение (analyzeIntegrity), а не рушить разбор всего конфига
-export const BalancerSchema = z
-  .object({
-    tag: z.string(),
-    selector: z.array(z.string()).optional(),
-    fallbackTag: z.string().optional(),
-    strategy: z
-      .object({
-        type: z.string().optional(),
-        settings: z.object({}).passthrough().optional(),
-      })
-      .passthrough()
-      .optional(),
-  })
-  .passthrough()
+export const BalancerSchema = z.looseObject({
+  tag: z.string(),
+  selector: z.array(z.string()).optional(),
+  fallbackTag: z.string().optional(),
+  strategy: z
+    .looseObject({
+      type: z.string().optional(),
+      settings: z.looseObject({}).optional(),
+    })
+    .optional(),
+})
 
 export type Balancer = z.infer<typeof BalancerSchema>
 

--- a/frontend/src/entities/xray/config.ts
+++ b/frontend/src/entities/xray/config.ts
@@ -9,10 +9,10 @@ import { OutboundSchema } from './outbounds'
 import { keywordEntries, portSpecError } from './rules'
 import { RoutingSchema } from './routing'
 
-const obj = () => z.object({}).passthrough()
+const obj = () => z.looseObject({})
 
-// Поднабор streamSettings, который читают проверки матрицы (схема — passthrough,
-// поэтому типизируем только нужные ключи)
+// Поднабор streamSettings, который читают проверки матрицы (схема пропускает
+// неизвестные поля, поэтому типизируем только нужные ключи)
 interface StreamSubset {
   network?: string
   security?: string
@@ -20,23 +20,21 @@ interface StreamSubset {
   sockopt?: { dialerProxy?: string }
 }
 
-export const XrayConfigSchema = z
-  .object({
-    log: LogSchema.optional(),
-    dns: DnsSchema.optional(),
-    inbounds: z.array(InboundSchema).optional(),
-    outbounds: z.array(OutboundSchema).optional(),
-    routing: RoutingSchema.optional(),
-    policy: obj().optional(),
-    transport: obj().optional(),
-    stats: obj().optional(),
-    reverse: obj().optional(),
-    fakedns: z.union([obj(), z.array(obj())]).optional(),
-    observatory: ObservatorySchema.optional(),
-    burstObservatory: BurstObservatorySchema.optional(),
-    api: obj().optional(),
-  })
-  .passthrough()
+export const XrayConfigSchema = z.looseObject({
+  log: LogSchema.optional(),
+  dns: DnsSchema.optional(),
+  inbounds: z.array(InboundSchema).optional(),
+  outbounds: z.array(OutboundSchema).optional(),
+  routing: RoutingSchema.optional(),
+  policy: obj().optional(),
+  transport: obj().optional(),
+  stats: obj().optional(),
+  reverse: obj().optional(),
+  fakedns: z.union([obj(), z.array(obj())]).optional(),
+  observatory: ObservatorySchema.optional(),
+  burstObservatory: BurstObservatorySchema.optional(),
+  api: obj().optional(),
+})
 
 export type XrayConfig = z.infer<typeof XrayConfigSchema>
 

--- a/frontend/src/entities/xray/dns.ts
+++ b/frontend/src/entities/xray/dns.ts
@@ -1,24 +1,20 @@
 import { z } from 'zod'
 
-export const DnsServerObjectSchema = z
-  .object({
-    address: z.string().optional(),
-    port: z.number().optional(),
-    domains: z.array(z.string()).optional(),
-    expectIPs: z.array(z.string()).optional(),
-    skipFallback: z.boolean().optional(),
-    queryStrategy: z.string().optional(),
-  })
-  .passthrough()
+export const DnsServerObjectSchema = z.looseObject({
+  address: z.string().optional(),
+  port: z.number().optional(),
+  domains: z.array(z.string()).optional(),
+  expectIPs: z.array(z.string()).optional(),
+  skipFallback: z.boolean().optional(),
+  queryStrategy: z.string().optional(),
+})
 
 export const DnsServerSchema = z.union([z.string(), DnsServerObjectSchema])
 
-export const DnsSchema = z
-  .object({
-    servers: z.array(DnsServerSchema).optional(),
-    hosts: z.record(z.string(), z.union([z.string(), z.array(z.string())])).optional(),
-    clientIp: z.string().optional(),
-    queryStrategy: z.string().optional(),
-    tag: z.string().optional(),
-  })
-  .passthrough()
+export const DnsSchema = z.looseObject({
+  servers: z.array(DnsServerSchema).optional(),
+  hosts: z.record(z.string(), z.union([z.string(), z.array(z.string())])).optional(),
+  clientIp: z.string().optional(),
+  queryStrategy: z.string().optional(),
+  tag: z.string().optional(),
+})

--- a/frontend/src/entities/xray/inbounds.ts
+++ b/frontend/src/entities/xray/inbounds.ts
@@ -1,63 +1,59 @@
 import { z } from 'zod'
 import { SniffingSchema, StreamSettingsSchema } from './stream'
 
-const obj = () => z.object({}).passthrough()
+const obj = () => z.looseObject({})
 
-export const VlessClientSchema = z
-  .object({ id: z.string().optional(), email: z.string().optional(), flow: z.string().optional() })
-  .passthrough()
+export const VlessClientSchema = z.looseObject({
+  id: z.string().optional(),
+  email: z.string().optional(),
+  flow: z.string().optional(),
+})
 
-export const FallbackSchema = z
-  .object({
-    name: z.string().optional(),
-    alpn: z.string().optional(),
-    path: z.string().optional(),
-    dest: z.union([z.string(), z.number()]).optional(),
-    xver: z.number().optional(),
-  })
-  .passthrough()
+export const FallbackSchema = z.looseObject({
+  name: z.string().optional(),
+  alpn: z.string().optional(),
+  path: z.string().optional(),
+  dest: z.union([z.string(), z.number()]).optional(),
+  xver: z.number().optional(),
+})
 
-export const TrojanClientSchema = z
-  .object({ password: z.string().optional(), email: z.string().optional(), level: z.number().optional() })
-  .passthrough()
+export const TrojanClientSchema = z.looseObject({
+  password: z.string().optional(),
+  email: z.string().optional(),
+  level: z.number().optional(),
+})
 
-export const HysteriaClientSchema = z
-  .object({ auth: z.string().optional(), email: z.string().optional(), level: z.number().optional() })
-  .passthrough()
+export const HysteriaClientSchema = z.looseObject({
+  auth: z.string().optional(),
+  email: z.string().optional(),
+  level: z.number().optional(),
+})
 
-export const HysteriaInboundSettingsSchema = z
-  .object({
-    version: z.number().optional(),
-    clients: z.array(HysteriaClientSchema).optional(),
-  })
-  .passthrough()
+export const HysteriaInboundSettingsSchema = z.looseObject({
+  version: z.number().optional(),
+  clients: z.array(HysteriaClientSchema).optional(),
+})
 
-export const VlessInboundSettingsSchema = z
-  .object({
-    clients: z.array(VlessClientSchema).optional(),
-    decryption: z.string().optional(),
-    fallbacks: z.array(FallbackSchema).optional(),
-  })
-  .passthrough()
+export const VlessInboundSettingsSchema = z.looseObject({
+  clients: z.array(VlessClientSchema).optional(),
+  decryption: z.string().optional(),
+  fallbacks: z.array(FallbackSchema).optional(),
+})
 
-export const TrojanInboundSettingsSchema = z
-  .object({
-    clients: z.array(TrojanClientSchema).optional(),
-    fallbacks: z.array(FallbackSchema).optional(),
-  })
-  .passthrough()
+export const TrojanInboundSettingsSchema = z.looseObject({
+  clients: z.array(TrojanClientSchema).optional(),
+  fallbacks: z.array(FallbackSchema).optional(),
+})
 
-export const ShadowsocksInboundSettingsSchema = z
-  .object({
-    method: z.string().optional(),
-    password: z.string().optional(),
-    clients: z.array(obj()).optional(),
-    network: z.string().optional(),
-  })
-  .passthrough()
+export const ShadowsocksInboundSettingsSchema = z.looseObject({
+  method: z.string().optional(),
+  password: z.string().optional(),
+  clients: z.array(obj()).optional(),
+  network: z.string().optional(),
+})
 
 export const InboundSchema = z
-  .object({
+  .looseObject({
     tag: z.string({ error: 'У inbound должен быть tag' }),
     port: z.union([z.number(), z.string()]).optional(),
     listen: z.string().optional(),
@@ -67,7 +63,6 @@ export const InboundSchema = z
     sniffing: SniffingSchema.optional(),
     allocate: obj().optional(),
   })
-  .passthrough()
   .superRefine((inb, ctx) => {
     const settingsSchema =
       inb.protocol === 'vless'

--- a/frontend/src/entities/xray/log.ts
+++ b/frontend/src/entities/xray/log.ts
@@ -1,10 +1,8 @@
 import { z } from 'zod'
 
-export const LogSchema = z
-  .object({
-    access: z.string().optional(),
-    error: z.string().optional(),
-    loglevel: z.string().optional(),
-    dnsLog: z.boolean().optional(),
-  })
-  .passthrough()
+export const LogSchema = z.looseObject({
+  access: z.string().optional(),
+  error: z.string().optional(),
+  loglevel: z.string().optional(),
+  dnsLog: z.boolean().optional(),
+})

--- a/frontend/src/entities/xray/observatory.ts
+++ b/frontend/src/entities/xray/observatory.ts
@@ -5,32 +5,26 @@
 import { z } from 'zod'
 import type { XrayConfig } from './config'
 
-export const ObservatorySchema = z
-  .object({
-    subjectSelector: z.array(z.string()).optional(),
-    probeUrl: z.string().optional(),
-    probeInterval: z.string().optional(),
-    enableConcurrency: z.boolean().optional(),
-  })
-  .passthrough()
+export const ObservatorySchema = z.looseObject({
+  subjectSelector: z.array(z.string()).optional(),
+  probeUrl: z.string().optional(),
+  probeInterval: z.string().optional(),
+  enableConcurrency: z.boolean().optional(),
+})
 
-export const PingConfigSchema = z
-  .object({
-    destination: z.string().optional(),
-    connectivity: z.string().optional(),
-    interval: z.string().optional(),
-    sampling: z.number().optional(),
-    timeout: z.string().optional(),
-    httpMethod: z.string().optional(),
-  })
-  .passthrough()
+export const PingConfigSchema = z.looseObject({
+  destination: z.string().optional(),
+  connectivity: z.string().optional(),
+  interval: z.string().optional(),
+  sampling: z.number().optional(),
+  timeout: z.string().optional(),
+  httpMethod: z.string().optional(),
+})
 
-export const BurstObservatorySchema = z
-  .object({
-    subjectSelector: z.array(z.string()).optional(),
-    pingConfig: PingConfigSchema.optional(),
-  })
-  .passthrough()
+export const BurstObservatorySchema = z.looseObject({
+  subjectSelector: z.array(z.string()).optional(),
+  pingConfig: PingConfigSchema.optional(),
+})
 
 export type Observatory = z.infer<typeof ObservatorySchema>
 export type BurstObservatory = z.infer<typeof BurstObservatorySchema>

--- a/frontend/src/entities/xray/outbounds.ts
+++ b/frontend/src/entities/xray/outbounds.ts
@@ -1,103 +1,87 @@
 import { z } from 'zod'
 import { StreamSettingsSchema } from './stream'
 
-const obj = () => z.object({}).passthrough()
+const obj = () => z.looseObject({})
 
-export const FreedomFragmentSchema = z
-  .object({
-    packets: z.string().optional(),
-    length: z.string().optional(),
-    interval: z.string().optional(),
-  })
-  .passthrough()
+export const FreedomFragmentSchema = z.looseObject({
+  packets: z.string().optional(),
+  length: z.string().optional(),
+  interval: z.string().optional(),
+})
 
-export const FreedomOutboundSettingsSchema = z
-  .object({
-    domainStrategy: z.string().optional(),
-    redirect: z.string().optional(),
-    fragment: FreedomFragmentSchema.optional(),
-    proxyProtocol: z.number().optional(),
-  })
-  .passthrough()
+export const FreedomOutboundSettingsSchema = z.looseObject({
+  domainStrategy: z.string().optional(),
+  redirect: z.string().optional(),
+  fragment: FreedomFragmentSchema.optional(),
+  proxyProtocol: z.number().optional(),
+})
 
-export const BlackholeOutboundSettingsSchema = z
-  .object({
-    response: z.object({ type: z.string().optional() }).passthrough().optional(),
-  })
-  .passthrough()
+export const BlackholeOutboundSettingsSchema = z.looseObject({
+  response: z.looseObject({ type: z.string().optional() }).optional(),
+})
 
-export const WireguardPeerSchema = z
-  .object({
-    publicKey: z.string().optional(),
-    endpoint: z.string().optional(),
-    allowedIPs: z.array(z.string()).optional(),
-    preSharedKey: z.string().optional(),
-    keepAlive: z.number().optional(),
-  })
-  .passthrough()
+export const WireguardPeerSchema = z.looseObject({
+  publicKey: z.string().optional(),
+  endpoint: z.string().optional(),
+  allowedIPs: z.array(z.string()).optional(),
+  preSharedKey: z.string().optional(),
+  keepAlive: z.number().optional(),
+})
 
-export const WireguardOutboundSettingsSchema = z
-  .object({
-    secretKey: z.string().optional(),
-    address: z.array(z.string()).optional(),
-    peers: z.array(WireguardPeerSchema).optional(),
-    mtu: z.number().optional(),
-    reserved: z.array(z.number()).optional(),
-    workers: z.number().optional(),
-    domainStrategy: z.string().optional(),
-    noKernelTun: z.boolean().optional(),
-  })
-  .passthrough()
+export const WireguardOutboundSettingsSchema = z.looseObject({
+  secretKey: z.string().optional(),
+  address: z.array(z.string()).optional(),
+  peers: z.array(WireguardPeerSchema).optional(),
+  mtu: z.number().optional(),
+  reserved: z.array(z.number()).optional(),
+  workers: z.number().optional(),
+  domainStrategy: z.string().optional(),
+  noKernelTun: z.boolean().optional(),
+})
 
-export const VlessOutboundUserSchema = z
-  .object({
-    id: z.string().optional(),
-    flow: z.string().optional(),
-    encryption: z.string().optional(),
-    level: z.number().optional(),
-  })
-  .passthrough()
+export const VlessOutboundUserSchema = z.looseObject({
+  id: z.string().optional(),
+  flow: z.string().optional(),
+  encryption: z.string().optional(),
+  level: z.number().optional(),
+})
 
-export const VlessVnextSchema = z
-  .object({
-    address: z.string().optional(),
-    port: z.number().optional(),
-    users: z.array(VlessOutboundUserSchema).optional(),
-  })
-  .passthrough()
+export const VlessVnextSchema = z.looseObject({
+  address: z.string().optional(),
+  port: z.number().optional(),
+  users: z.array(VlessOutboundUserSchema).optional(),
+})
 
-export const VlessOutboundSettingsSchema = z
-  .object({ vnext: z.array(VlessVnextSchema).optional() })
-  .passthrough()
+export const VlessOutboundSettingsSchema = z.looseObject({
+  vnext: z.array(VlessVnextSchema).optional(),
+})
 
-export const ProxyServerUserSchema = z
-  .object({ user: z.string().optional(), pass: z.string().optional(), level: z.number().optional() })
-  .passthrough()
+export const ProxyServerUserSchema = z.looseObject({
+  user: z.string().optional(),
+  pass: z.string().optional(),
+  level: z.number().optional(),
+})
 
-export const ProxyServerSchema = z
-  .object({
-    address: z.string().optional(),
-    port: z.number().optional(),
-    users: z.array(ProxyServerUserSchema).optional(),
-  })
-  .passthrough()
+export const ProxyServerSchema = z.looseObject({
+  address: z.string().optional(),
+  port: z.number().optional(),
+  users: z.array(ProxyServerUserSchema).optional(),
+})
 
-export const SocksOutboundSettingsSchema = z
-  .object({ servers: z.array(ProxyServerSchema).optional() })
-  .passthrough()
+export const SocksOutboundSettingsSchema = z.looseObject({
+  servers: z.array(ProxyServerSchema).optional(),
+})
 
-export const HttpOutboundSettingsSchema = z
-  .object({ servers: z.array(ProxyServerSchema).optional() })
-  .passthrough()
+export const HttpOutboundSettingsSchema = z.looseObject({
+  servers: z.array(ProxyServerSchema).optional(),
+})
 
-export const MuxSchema = z
-  .object({
-    enabled: z.boolean().optional(),
-    concurrency: z.number().optional(),
-    xudpConcurrency: z.number().optional(),
-    xudpProxyUDP443: z.string().optional(),
-  })
-  .passthrough()
+export const MuxSchema = z.looseObject({
+  enabled: z.boolean().optional(),
+  concurrency: z.number().optional(),
+  xudpConcurrency: z.number().optional(),
+  xudpProxyUDP443: z.string().optional(),
+})
 
 const OUTBOUND_SETTINGS_BY_PROTOCOL: Record<string, z.ZodTypeAny> = {
   freedom: FreedomOutboundSettingsSchema,
@@ -109,7 +93,7 @@ const OUTBOUND_SETTINGS_BY_PROTOCOL: Record<string, z.ZodTypeAny> = {
 }
 
 export const OutboundSchema = z
-  .object({
+  .looseObject({
     tag: z.string({ error: 'У outbound должен быть tag' }),
     protocol: z.string({ error: 'У outbound должен быть protocol' }),
     settings: obj().optional(),
@@ -118,7 +102,6 @@ export const OutboundSchema = z
     sendThrough: z.string().optional(),
     mux: MuxSchema.optional(),
   })
-  .passthrough()
   .superRefine((out, ctx) => {
     const settingsSchema = OUTBOUND_SETTINGS_BY_PROTOCOL[out.protocol]
     if (settingsSchema && out.settings !== undefined) {

--- a/frontend/src/entities/xray/routing.ts
+++ b/frontend/src/entities/xray/routing.ts
@@ -1,28 +1,24 @@
 import { z } from 'zod'
 import { BalancerSchema } from './balancers'
 
-export const RoutingRuleSchema = z
-  .object({
-    type: z.string().optional(),
-    inboundTag: z.array(z.string()).optional(),
-    outboundTag: z.string().optional(),
-    balancerTag: z.string().optional(),
-    domain: z.array(z.string()).optional(),
-    ip: z.array(z.string()).optional(),
-    port: z.union([z.string(), z.number()]).optional(),
-    sourcePort: z.union([z.string(), z.number()]).optional(),
-    network: z.string().optional(),
-    protocol: z.array(z.string()).optional(),
-    user: z.array(z.string()).optional(),
-    source: z.array(z.string()).optional(),
-  })
-  .passthrough()
+export const RoutingRuleSchema = z.looseObject({
+  type: z.string().optional(),
+  inboundTag: z.array(z.string()).optional(),
+  outboundTag: z.string().optional(),
+  balancerTag: z.string().optional(),
+  domain: z.array(z.string()).optional(),
+  ip: z.array(z.string()).optional(),
+  port: z.union([z.string(), z.number()]).optional(),
+  sourcePort: z.union([z.string(), z.number()]).optional(),
+  network: z.string().optional(),
+  protocol: z.array(z.string()).optional(),
+  user: z.array(z.string()).optional(),
+  source: z.array(z.string()).optional(),
+})
 
-export const RoutingSchema = z
-  .object({
-    domainStrategy: z.string().optional(),
-    domainMatcher: z.string().optional(),
-    rules: z.array(RoutingRuleSchema).optional(),
-    balancers: z.array(BalancerSchema).optional(),
-  })
-  .passthrough()
+export const RoutingSchema = z.looseObject({
+  domainStrategy: z.string().optional(),
+  domainMatcher: z.string().optional(),
+  rules: z.array(RoutingRuleSchema).optional(),
+  balancers: z.array(BalancerSchema).optional(),
+})

--- a/frontend/src/entities/xray/stream.ts
+++ b/frontend/src/entities/xray/stream.ts
@@ -1,151 +1,123 @@
 import { z } from 'zod'
 
-const obj = () => z.object({}).passthrough()
+const obj = () => z.looseObject({})
 
-export const RealitySettingsSchema = z
-  .object({
-    show: z.boolean().optional(),
-    dest: z.union([z.string(), z.number()]).optional(),
-    target: z.union([z.string(), z.number()]).optional(),
-    xver: z.number().optional(),
-    serverNames: z.array(z.string()).optional(),
-    privateKey: z.string().optional(),
-    publicKey: z.string().optional(),
-    shortIds: z.array(z.string()).optional(),
-    fingerprint: z.string().optional(),
-    spiderX: z.string().optional(),
-    serverName: z.string().optional(),
-    shortId: z.string().optional(),
-    password: z.string().optional(),
-  })
-  .passthrough()
+export const RealitySettingsSchema = z.looseObject({
+  show: z.boolean().optional(),
+  dest: z.union([z.string(), z.number()]).optional(),
+  target: z.union([z.string(), z.number()]).optional(),
+  xver: z.number().optional(),
+  serverNames: z.array(z.string()).optional(),
+  privateKey: z.string().optional(),
+  publicKey: z.string().optional(),
+  shortIds: z.array(z.string()).optional(),
+  fingerprint: z.string().optional(),
+  spiderX: z.string().optional(),
+  serverName: z.string().optional(),
+  shortId: z.string().optional(),
+  password: z.string().optional(),
+})
 
-export const CertificateSchema = z
-  .object({
-    certificateFile: z.string().optional(),
-    keyFile: z.string().optional(),
-    certificate: z.array(z.string()).optional(),
-    key: z.array(z.string()).optional(),
-    usage: z.string().optional(),
-  })
-  .passthrough()
+export const CertificateSchema = z.looseObject({
+  certificateFile: z.string().optional(),
+  keyFile: z.string().optional(),
+  certificate: z.array(z.string()).optional(),
+  key: z.array(z.string()).optional(),
+  usage: z.string().optional(),
+})
 
-export const TlsSettingsSchema = z
-  .object({
-    serverName: z.string().optional(),
-    rejectUnknownSni: z.boolean().optional(),
-    alpn: z.array(z.string()).optional(),
-    certificates: z.array(CertificateSchema).optional(),
-    minVersion: z.string().optional(),
-    maxVersion: z.string().optional(),
-    fingerprint: z.string().optional(),
-  })
-  .passthrough()
+export const TlsSettingsSchema = z.looseObject({
+  serverName: z.string().optional(),
+  rejectUnknownSni: z.boolean().optional(),
+  alpn: z.array(z.string()).optional(),
+  certificates: z.array(CertificateSchema).optional(),
+  minVersion: z.string().optional(),
+  maxVersion: z.string().optional(),
+  fingerprint: z.string().optional(),
+})
 
-export const TcpSettingsSchema = z
-  .object({
-    acceptProxyProtocol: z.boolean().optional(),
-    header: obj().optional(),
-  })
-  .passthrough()
+export const TcpSettingsSchema = z.looseObject({
+  acceptProxyProtocol: z.boolean().optional(),
+  header: obj().optional(),
+})
 
-export const WsSettingsSchema = z
-  .object({
-    path: z.string().optional(),
-    host: z.string().optional(),
-    headers: z.record(z.string(), z.string()).optional(),
-    heartbeatPeriod: z.number().optional(),
-    acceptProxyProtocol: z.boolean().optional(),
-  })
-  .passthrough()
+export const WsSettingsSchema = z.looseObject({
+  path: z.string().optional(),
+  host: z.string().optional(),
+  headers: z.record(z.string(), z.string()).optional(),
+  heartbeatPeriod: z.number().optional(),
+  acceptProxyProtocol: z.boolean().optional(),
+})
 
-export const GrpcSettingsSchema = z
-  .object({
-    serviceName: z.string().optional(),
-    authority: z.string().optional(),
-    multiMode: z.boolean().optional(),
-  })
-  .passthrough()
+export const GrpcSettingsSchema = z.looseObject({
+  serviceName: z.string().optional(),
+  authority: z.string().optional(),
+  multiMode: z.boolean().optional(),
+})
 
-export const HttpupgradeSettingsSchema = z
-  .object({
-    path: z.string().optional(),
-    host: z.string().optional(),
-    headers: z.record(z.string(), z.string()).optional(),
-    acceptProxyProtocol: z.boolean().optional(),
-  })
-  .passthrough()
+export const HttpupgradeSettingsSchema = z.looseObject({
+  path: z.string().optional(),
+  host: z.string().optional(),
+  headers: z.record(z.string(), z.string()).optional(),
+  acceptProxyProtocol: z.boolean().optional(),
+})
 
-export const XhttpSettingsSchema = z
-  .object({
-    path: z.string().optional(),
-    host: z.string().optional(),
-    mode: z.string().optional(),
-    extra: obj().optional(),
-  })
-  .passthrough()
+export const XhttpSettingsSchema = z.looseObject({
+  path: z.string().optional(),
+  host: z.string().optional(),
+  mode: z.string().optional(),
+  extra: obj().optional(),
+})
 
-export const HysteriaSettingsSchema = z
-  .object({
-    version: z.number().optional(),
-    auth: z.string().optional(),
-    up: z.string().optional(),
-    down: z.string().optional(),
-    udpIdleTimeout: z.number().optional(),
-    masquerade: obj().optional(),
-  })
-  .passthrough()
+export const HysteriaSettingsSchema = z.looseObject({
+  version: z.number().optional(),
+  auth: z.string().optional(),
+  up: z.string().optional(),
+  down: z.string().optional(),
+  udpIdleTimeout: z.number().optional(),
+  masquerade: obj().optional(),
+})
 
-export const QuicParamsSchema = z
-  .object({
-    congestion: z.string().optional(),
-    brutalUp: z.number().optional(),
-    brutalDown: z.number().optional(),
-  })
-  .passthrough()
+export const QuicParamsSchema = z.looseObject({
+  congestion: z.string().optional(),
+  brutalUp: z.number().optional(),
+  brutalDown: z.number().optional(),
+})
 
-export const FinalmaskSchema = z
-  .object({
-    quicParams: QuicParamsSchema.optional(),
-  })
-  .passthrough()
+export const FinalmaskSchema = z.looseObject({
+  quicParams: QuicParamsSchema.optional(),
+})
 
-export const SockoptSchema = z
-  .object({
-    mark: z.number().optional(),
-    tcpFastOpen: z.union([z.boolean(), z.number()]).optional(),
-    tproxy: z.string().optional(),
-    domainStrategy: z.string().optional(),
-    dialerProxy: z.string().optional(),
-    acceptProxyProtocol: z.boolean().optional(),
-    interface: z.string().optional(),
-    tcpMptcp: z.boolean().optional(),
-  })
-  .passthrough()
+export const SockoptSchema = z.looseObject({
+  mark: z.number().optional(),
+  tcpFastOpen: z.union([z.boolean(), z.number()]).optional(),
+  tproxy: z.string().optional(),
+  domainStrategy: z.string().optional(),
+  dialerProxy: z.string().optional(),
+  acceptProxyProtocol: z.boolean().optional(),
+  interface: z.string().optional(),
+  tcpMptcp: z.boolean().optional(),
+})
 
-export const StreamSettingsSchema = z
-  .object({
-    network: z.string().optional(),
-    security: z.string().optional(),
-    realitySettings: RealitySettingsSchema.optional(),
-    tlsSettings: TlsSettingsSchema.optional(),
-    tcpSettings: TcpSettingsSchema.optional(),
-    rawSettings: TcpSettingsSchema.optional(),
-    wsSettings: WsSettingsSchema.optional(),
-    grpcSettings: GrpcSettingsSchema.optional(),
-    httpupgradeSettings: HttpupgradeSettingsSchema.optional(),
-    xhttpSettings: XhttpSettingsSchema.optional(),
-    hysteriaSettings: HysteriaSettingsSchema.optional(),
-    finalmask: FinalmaskSchema.optional(),
-    sockopt: SockoptSchema.optional(),
-  })
-  .passthrough()
+export const StreamSettingsSchema = z.looseObject({
+  network: z.string().optional(),
+  security: z.string().optional(),
+  realitySettings: RealitySettingsSchema.optional(),
+  tlsSettings: TlsSettingsSchema.optional(),
+  tcpSettings: TcpSettingsSchema.optional(),
+  rawSettings: TcpSettingsSchema.optional(),
+  wsSettings: WsSettingsSchema.optional(),
+  grpcSettings: GrpcSettingsSchema.optional(),
+  httpupgradeSettings: HttpupgradeSettingsSchema.optional(),
+  xhttpSettings: XhttpSettingsSchema.optional(),
+  hysteriaSettings: HysteriaSettingsSchema.optional(),
+  finalmask: FinalmaskSchema.optional(),
+  sockopt: SockoptSchema.optional(),
+})
 
-export const SniffingSchema = z
-  .object({
-    enabled: z.boolean().optional(),
-    destOverride: z.array(z.string()).optional(),
-    routeOnly: z.boolean().optional(),
-    metadataOnly: z.boolean().optional(),
-  })
-  .passthrough()
+export const SniffingSchema = z.looseObject({
+  enabled: z.boolean().optional(),
+  destOverride: z.array(z.string()).optional(),
+  routeOnly: z.boolean().optional(),
+  metadataOnly: z.boolean().optional(),
+})

--- a/frontend/test/xray-config.test.ts
+++ b/frontend/test/xray-config.test.ts
@@ -42,8 +42,34 @@ const fullConfig = {
 }
 
 describe('XrayConfigSchema', () => {
-  it('passthrough round-trip: parse возвращает deep-equal объект', () => {
+  it('round-trip: parse возвращает deep-equal объект', () => {
     expect(XrayConfigSchema.parse(fullConfig)).toEqual(fullConfig)
+  })
+
+  // Схемы объявлены через z.looseObject именно ради этого: чужой конфиг
+  // переживает редактирование, даже если поле нам незнакомо.
+  it('незнакомые ключи не теряются на всех уровнях вложенности', () => {
+    const exotic = {
+      inbounds: [
+        {
+          tag: 'in',
+          protocol: 'vless',
+          неизвестноеПоле: 1,
+          streamSettings: {
+            network: 'raw',
+            futureTransport: { mode: 'x' },
+            realitySettings: { dest: 'a:443', futureKnob: true },
+          },
+          sniffing: { enabled: true, futureSniff: 'y' },
+        },
+      ],
+      outbounds: [{ tag: 'out', protocol: 'freedom', futureOutboundOpt: [1, 2] }],
+      routing: {
+        rules: [{ type: 'field', outboundTag: 'out', futureMatcher: 'z' }],
+        balancers: [{ tag: 'bal', selector: ['out'], futureBalancerOpt: {} }],
+      },
+    }
+    expect(XrayConfigSchema.parse(exotic)).toEqual(exotic)
   })
 })
 


### PR DESCRIPTION
Уборка, отложенная при переходе на zod 4 (#13): `.passthrough()` там помечен deprecated, а `z.looseObject` — та же схема, записанная одним вызовом вместо двух. Все 54 места переехали, включая два комментария, называвших старое имя.

## Три формы записи

Правка механическая, но встречалась в трёх видах, и каждый обработан по-своему:

| Форма | Было | Стало |
|---|---|---|
| Хвостовой вызов (47) | `z`<br>`  .object({…})`<br>`  .passthrough()` | `z.looseObject({…})` |
| Цепочка продолжается (4) | `…​.passthrough()`<br>`  .superRefine(…)` | `z`<br>`  .looseObject({…})`<br>`  .superRefine(…)` |
| Тело в одну строку (7) | `.object({ id: …, email: … })` | свойства разложены по строкам |

Однострочники я не схлопывал в одну строку намеренно: `z.looseObject({ id: …, email: …, flow: … })` выходил за 130 символов, шире всего остального файла.

Цепочка сохранена там, где после схемы идёт что-то ещё — `.superRefine` у `InboundSchema` и `OutboundSchema`, `.optional()` у `strategy` в балансере.

## Как читать дифф

**`git diff -w`** — почти весь объём правки это тело каждой схемы, потерявшее один уровень отступа. Без пробельных изменений остаётся 79 добавленных и 150 удалённых строк, и там видно только суть.

## Поведение не меняется — и это проверено

Round-trip неизвестных полей — причина, по которой схемы вообще объявлены «свободными»: чужой конфиг с незнакомым нам полем обязан пережить редактирование. Тест на это был, но проверял верхний уровень и `dns`. Добавил случай на каждый переписанный уровень: `inbound`, `streamSettings`, `realitySettings`, `sniffing`, `outbound`, правило маршрутизации и балансер — каждый сохраняет ключ, которого схема никогда не видела.

Локально: typecheck обоих workspace чист, 673 фронтенд-теста (было 672), обе сборки проходят.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
