### PR TITLE
fix(frontend): balancer strategy without its observatory is an error

### DIFF
--- a/backend/src/xray/parseOutput.ts
+++ b/backend/src/xray/parseOutput.ts
@@ -41,6 +41,12 @@ const HINTS: { pattern: RegExp; hint: string; code?: 'geo' }[] = [
     pattern: /no such file or directory/i,
     hint: 'Конфиг ссылается на файл, которого нет на диске рядом с ядром (сертификат, ключ, лог).',
   },
+  {
+    // Ядро говорит об этом одной фразой без имён: проверено на v26.6.27 —
+    // так выглядит leastPing без observatory и leastLoad без burstObservatory.
+    pattern: /not all dependencies are resolved/i,
+    hint: 'Стратегия балансера требует секцию измерений: leastPing — observatory, leastLoad — burstObservatory. Без неё ядро не стартует.',
+  },
 ]
 
 /**

--- a/backend/test/xray-parse-output.test.ts
+++ b/backend/test/xray-parse-output.test.ts
@@ -93,6 +93,13 @@ describe('parseXrayOutput', () => {
         'Failed to start: main: failed to load config files: [/x.json] > infra/conf: Failed to build REALITY config. > infra/conf: empty "serverNames"'
       expect(parseXrayOutput(out, '/x.json')[0]!.hint).toMatch(/serverNames/)
     })
+
+    // Дословный ответ ядра v26.6.27 на leastPing без observatory: ни имени
+    // балансера, ни имени секции — без подсказки текст ничего не говорит.
+    it('стратегия балансера без секции измерений — ядро отвечает про зависимости', () => {
+      const out = 'Failed to start: main: failed to create server > core: not all dependencies are resolved.'
+      expect(parseXrayOutput(out, '/x.json')[0]!.hint).toMatch(/observatory/)
+    })
   })
 })
 

--- a/frontend/src/entities/xray/config.ts
+++ b/frontend/src/entities/xray/config.ts
@@ -201,11 +201,14 @@ export function analyzeIntegrity(config: XrayConfig): ValidationIssue[] {
       const kindKey = type === 'leastPing' ? 'observatory' : 'burstObservatory'
       const section = config[kindKey]
       if (section === undefined) {
+        // Не предупреждение: проверено на ядре v26.6.27 — без секции оно
+        // отказывается стартовать («not all dependencies are resolved»),
+        // то есть нода с таким конфигом просто не поднимется.
         issues.push(
           issue(
             ['routing', 'balancers', i, 'strategy'],
-            `Стратегия ${type} измеряет выходы через ${kindKey} — этой секции в конфиге нет`,
-            'warning',
+            `Стратегия ${type} измеряет выходы через ${kindKey} — без этой секции ядро не запустится`,
+            'error',
           ),
         )
       } else {

--- a/frontend/src/features/inspector/BalancerForm.tsx
+++ b/frontend/src/features/inspector/BalancerForm.tsx
@@ -101,7 +101,8 @@ export function BalancerForm({
           {observatory?.present !== true ? (
             <>
               <span className="field-warning">
-                Стратегия {strategy} измеряет выходы, а секции {sectionName} в конфиге нет
+                Стратегия {strategy} измеряет выходы через {sectionName} — без этой секции ядро не
+                запустится
               </span>
               {onSetupObservatory && (
                 <Button onClick={() => onSetupObservatory(kind, candidates)}>

--- a/frontend/test/xray-config.test.ts
+++ b/frontend/test/xray-config.test.ts
@@ -499,16 +499,18 @@ describe('валидация балансеров', () => {
     expect(found.some((m) => m.startsWith('warning:routing.balancers.0.fallbackTag'))).toBe(true)
   })
 
-  it('leastPing без observatory — предупреждение, с ней — нет', () => {
+  // Уровень проверен на ядре v26.6.27 (2026-07-26): без секции измерений оно
+  // отвечает «not all dependencies are resolved» и не стартует.
+  it('leastPing без observatory — ошибка, с ней — чисто', () => {
     const bal = [{ tag: 'bal', selector: ['proxy-'], strategy: { type: 'leastPing' } }]
-    expect(messages(cfg(bal)).some((m) => m.startsWith('warning:routing.balancers.0.strategy'))).toBe(true)
+    expect(messages(cfg(bal)).some((m) => m.startsWith('error:routing.balancers.0.strategy'))).toBe(true)
     const ok = messages(cfg(bal, { observatory: { subjectSelector: ['proxy-'] } }))
-    expect(ok.some((m) => m.startsWith('warning:routing.balancers.0.strategy'))).toBe(false)
+    expect(ok.some((m) => m.startsWith('error:routing.balancers.0.strategy'))).toBe(false)
   })
 
-  it('leastLoad без burstObservatory — предупреждение', () => {
+  it('leastLoad без burstObservatory — ошибка', () => {
     const found = messages(cfg([{ tag: 'bal', selector: ['proxy-'], strategy: { type: 'leastLoad' } }]))
-    expect(found.some((m) => m.startsWith('warning:routing.balancers.0.strategy'))).toBe(true)
+    expect(found.some((m) => m.startsWith('error:routing.balancers.0.strategy'))).toBe(true)
   })
 
   it('subjectSelector не покрывает кандидата — предупреждение', () => {


### PR DESCRIPTION
Найдено смоук-тестом прод-образа: в редакторе это было предупреждение, а ядро с таким конфигом **не стартует**.

## Что показало ядро

Прогон против ядра v26.6.27, вшитого в образ:

| Конфиг | Ответ ядра |
|---|---|
| `leastPing` без `observatory` | `failed to create server > core: not all dependencies are resolved.` |
| `leastPing` с `observatory` | `Configuration OK` |
| `leastLoad` без `burstObservatory` | та же ошибка |

Вопрос «откажется ли Xray стартовать» висел открытым с реализации балансеров — предупреждение поставили, потому что никто не проверял. Проверка отвечает: откажется.

Цена ошибки в том, что редактор одобрял конфиг, с которым нода не поднимется. Диагностика теперь `error`, и текст говорит следствие, а не наблюдение: «без этой секции ядро не запустится».

## Подсказка к ошибке ядра

Ядро не называет ни балансер, ни недостающую секцию — фраза `not all dependencies are resolved` сама по себе не говорит ничего. `parseOutput` переводит её в подсказку с именами: `leastPing` → `observatory`, `leastLoad` → `burstObservatory`.

Форма балансера приведена к той же формулировке, что и диагностика, вместо более мягкого «секции нет».

## Проверено

Юниты: 214 backend (+1 на подсказку) и 673 frontend, оба typecheck чисты. Существующие тесты, закреплявшие уровень `warning`, обновлены осознанно — они фиксировали поведение, которое оказалось неверным.

Сверх юнитов — пересобранный образ и повторный прогон на живом ядре: подсказка приходит в ответе `/api/tools/xray-test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
