### PR TITLE
chore: tag releases as vX.Y.Z and drop the one-shot release-as

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,10 +1,11 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "include-component-in-tag": false,
+  "pull-request-title-pattern": "chore: release ${version}",
   "packages": {
     ".": {
       "release-type": "node",
-      "changelog-path": "CHANGELOG.md",
-      "release-as": "1.0.0"
+      "changelog-path": "CHANGELOG.md"
     }
   }
 }


### PR DESCRIPTION
Две правки конфига release-please, обе — уборка после первого релиза.

**`include-component-in-tag: false`.** В manifest-режиме release-please по умолчанию подставляет в тег имя компонента, взятое из `name` в `package.json`. Для монорепо это правильно, для одного приложения — лишнее: первый релиз вышел тегом `xray-ui-editor-v1.0.0` вместо `v1.0.0`, и бейдж версии в README показывал бы именно его.

Тег и релиз 1.0.0 уже пересозданы вручную под именем `v1.0.0` (описание перенесено дословно, на тот же коммит `b59c8a7`); эта правка нужна, чтобы префикс не вернулся на следующем релизе. Теги образа затронуты не были — они берутся из отдельного output'а версии и с самого начала были верными: `1.0.0`, `1.0`, `1`, `latest`.

**`release-as` убран.** Одноразовая строка, нужная только чтобы первый релиз вышел ровно 1.0.0. Оставь её — и каждый следующий релиз пытался бы выпуститься как 1.0.0 и падал на существующем теге.

Заодно задан явный `pull-request-title-pattern`, чтобы заголовок релизного PR тоже не содержал имени компонента.

🤖 Generated with [Claude Code](https://claude.com/claude-code)