### PR TITLE
fix: keep the cause chain when the panel is unreachable

### DIFF
--- a/backend/src/remnawave/client.ts
+++ b/backend/src/remnawave/client.ts
@@ -11,6 +11,26 @@ export class RemnawaveError extends Error {
   }
 }
 
+/**
+ * Разворачивает цепочку `cause`. `fetch` в Node на любую сетевую беду отвечает
+ * одинаковым `TypeError: fetch failed`, а настоящая причина (ECONNREFUSED,
+ * EAI_AGAIN, обрыв TLS) лежит глубже. Без разворота диагностика упирается в
+ * сообщение, которое не говорит ничего.
+ */
+export function describeCause(err: unknown, depth = 4): string {
+  const parts: string[] = []
+  let cur: unknown = err
+  for (let i = 0; i <= depth && cur; i++) {
+    const e = cur as { message?: string; code?: string; cause?: unknown }
+    const text = e.message ?? String(cur)
+    const code = e.code ? ` (${e.code})` : ''
+    const line = `${text}${code}`
+    if (parts[parts.length - 1] !== line) parts.push(line)
+    cur = e.cause
+  }
+  return parts.join(' ← ')
+}
+
 interface ClientOptions {
   baseUrl: string
   token: string
@@ -33,7 +53,7 @@ export class RemnawaveClient implements RemnawavePort {
         body: body === undefined ? undefined : JSON.stringify(body),
       })
     } catch (err) {
-      throw new RemnawaveError(502, 'Панель Remnawave недоступна', String(err))
+      throw new RemnawaveError(502, 'Панель Remnawave недоступна', describeCause(err))
     }
     const text = await res.text()
     let json: unknown

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -75,6 +75,9 @@ export async function buildServer(
 
   app.setErrorHandler((err: FastifyError, req, reply) => {
     if (err instanceof RemnawaveError) {
+      // В лог — обязательно: связь с панелью чинят по логам, а раньше причина
+      // уходила только в тело ответа и была видна лишь через DevTools.
+      req.log.warn({ status: err.status, details: err.details }, err.message)
       return reply.status(err.status).send({ message: err.message, details: err.details })
     }
     if (err instanceof ZodError) {

--- a/backend/test/remnawave-client.test.ts
+++ b/backend/test/remnawave-client.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { RemnawaveClient, RemnawaveError } from '../src/remnawave/client.js'
+import { RemnawaveClient, RemnawaveError, describeCause } from '../src/remnawave/client.js'
 
 interface FakeCall { url: string; init: RequestInit }
 
@@ -110,6 +110,29 @@ describe('RemnawaveClient', () => {
     expect(err).toBeInstanceOf(RemnawaveError)
     expect(err.status).toBe(502)
     expect(err.message).toBe('Панель Remnawave недоступна')
+  })
+
+  // fetch в Node на любую сетевую беду отвечает одинаковым «fetch failed»,
+  // а настоящая причина лежит в cause. Без разворота диагностика упирается
+  // в сообщение, которое не называет ничего.
+  it('в details попадает вся цепочка cause, а не только верхняя ошибка', async () => {
+    const cause = Object.assign(new Error('other side closed'), { code: 'UND_ERR_SOCKET' })
+    const client = new RemnawaveClient({
+      baseUrl: 'http://panel.test',
+      token: 't',
+      fetchImpl: (async () => {
+        throw Object.assign(new TypeError('fetch failed'), { cause })
+      }) as typeof fetch,
+    })
+    const err = await client.listProfiles().catch((e) => e)
+    expect(err.details).toBe('fetch failed ← other side closed (UND_ERR_SOCKET)')
+  })
+
+  it('цепочка cause не зацикливается и не дублирует одинаковые звенья', async () => {
+    const loop: { message: string; cause?: unknown } = { message: 'зациклено' }
+    loop.cause = loop
+    expect(describeCause(loop)).toBe('зациклено')
+    expect(describeCause('строка вместо ошибки')).toBe('строка вместо ошибки')
   })
 
   it('getSquads разворачивает internalSquads, getNodes — массив response', async () => {

--- a/frontend/src/features/profiles/ProfilesPage.tsx
+++ b/frontend/src/features/profiles/ProfilesPage.tsx
@@ -1,6 +1,6 @@
 import { useState, type CSSProperties } from 'react'
 import { Link, useNavigate } from 'react-router'
-import { useDeleteProfile, useLogout, useProfiles, type PanelInboundView, type Profile } from '../../shared/api'
+import { causeOf, useDeleteProfile, useLogout, useProfiles, type PanelInboundView, type Profile } from '../../shared/api'
 import { relativeTime } from '../../shared/lib/relativeTime'
 import { Button, Card, Chip, Dialog, EmptyState } from '../../shared/ui'
 import { useDraftStore } from '../editor/draftStore'
@@ -121,7 +121,17 @@ export function ProfilesPage() {
       </div>
 
       {profiles.isPending && <p className="muted">Загрузка профилей…</p>}
-      {profiles.isError && <p className="field-error">{(profiles.error as Error).message}</p>}
+      {profiles.isError && (
+        <p className="field-error">
+          {(profiles.error as Error).message}
+          {causeOf(profiles.error) && (
+            <>
+              <br />
+              <span className="muted">{causeOf(profiles.error)}</span>
+            </>
+          )}
+        </p>
+      )}
 
       {profiles.data && profiles.data.length === 0 && (
         <EmptyState

--- a/frontend/src/shared/api/client.ts
+++ b/frontend/src/shared/api/client.ts
@@ -13,6 +13,17 @@ export class ApiError extends Error {
 
 export class AuthError extends ApiError {}
 
+/**
+ * Причина сбоя, которую бэкенд кладёт в `details` тела ответа. Само сообщение
+ * («Панель Remnawave недоступна») называет симптом, но не говорит, что
+ * проверять; причина отвечает на это — её и показываем рядом.
+ */
+export function causeOf(err: unknown): string | undefined {
+  if (!(err instanceof ApiError)) return undefined
+  const cause = (err.details as { details?: unknown } | undefined)?.details
+  return typeof cause === 'string' && cause.trim() !== '' ? cause : undefined
+}
+
 export class ConflictError extends ApiError {
   constructor(
     message: string,

--- a/frontend/test/api-client.test.ts
+++ b/frontend/test/api-client.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { apiFetch, ApiError, AuthError, ConflictError, useProfileInbounds, useSquads } from '../src/shared/api'
+import { apiFetch, ApiError, AuthError, causeOf, ConflictError, useProfileInbounds, useSquads } from '../src/shared/api'
 
 function mockFetch(status: number, body: unknown) {
   const fn = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>
@@ -66,5 +66,24 @@ describe('api hooks', () => {
   it('экспортирует хуки контекста панели', () => {
     expect(typeof useSquads).toBe('function')
     expect(typeof useProfileInbounds).toBe('function')
+  })
+})
+
+describe('causeOf', () => {
+  // Бэкенд заворачивает сетевую беду в 502 с человеческим сообщением, а
+  // машинную причину кладёт в details. Само сообщение называет симптом,
+  // причина — то, что надо чинить.
+  it('достаёт причину из тела ответа', () => {
+    const err = new ApiError(502, 'Панель Remnawave недоступна', {
+      message: 'Панель Remnawave недоступна',
+      details: 'fetch failed ← other side closed (UND_ERR_SOCKET)',
+    })
+    expect(causeOf(err)).toBe('fetch failed ← other side closed (UND_ERR_SOCKET)')
+  })
+
+  it('молчит, когда причины нет', () => {
+    expect(causeOf(new ApiError(404, 'Не найдено'))).toBeUndefined()
+    expect(causeOf(new ApiError(502, 'Недоступна', { details: '  ' }))).toBeUndefined()
+    expect(causeOf(new Error('обычная ошибка'))).toBeUndefined()
   })
 })


### PR DESCRIPTION
Диагностика связи с панелью упиралась в сообщение, которое не называет ничего.

## Что было

`fetch` в Node на **любую** сетевую беду отвечает одинаковым `TypeError: fetch failed` — настоящая причина лежит в `err.cause`. Клиент писал `String(err)`, то есть выбрасывал её:

```
{"message":"Панель Remnawave недоступна","details":"TypeError: fetch failed"}
```

Хуже того, `RemnawaveError` возвращался клиенту **в обход логирования**: оператор, у которого не поднимается связь с панелью, смотрит в `docker logs` и не находит там ничего. Единственным местом с причиной оставалась вкладка Network в DevTools.

## Что стало

`describeCause` разворачивает цепочку `cause` (до 4 звеньев, с кодом ошибки и защитой от циклов):

```
{"message":"Панель Remnawave недоступна","details":"fetch failed ← other side closed (UND_ERR_SOCKET)"}
```

Обработчик ошибок пишет `RemnawaveError` в лог на уровне `warn` — теперь это видно в `docker logs`.

Фронтенд показывает причину второй строкой под сообщением (`causeOf` в `shared/api`): «Панель Remnawave недоступна» отвечает на вопрос «что», причина — на вопрос «что чинить».

## Проверено

216 backend (+2) и 678 frontend (+2) тестов, оба typecheck чисты. Тесты покрывают разворот цепочки, зацикленный `cause`, строку вместо ошибки и отсутствие причины.

Найдено на живой установке: панель принимала TCP-соединение и молча закрывала сокет, а сообщение об этом молчало не хуже неё.

🤖 Generated with [Claude Code](https://claude.com/claude-code)