### PR TITLE
Совместимость с Remnawave 3.4.3 и внятная реакция на истёкший токен панели

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@
 ![Node](https://img.shields.io/badge/Node-24_LTS-339933?logo=node.js&logoColor=white)
 ![React](https://img.shields.io/badge/React-19-61DAFB?logo=react&logoColor=black)
 ![TypeScript](https://img.shields.io/badge/TypeScript-7-3178C6?logo=typescript&logoColor=white)
-![Remnawave](https://img.shields.io/badge/Remnawave-3.2.1-6E56CF)
-![tests](https://img.shields.io/badge/tests-951_passing-brightgreen)
+![Remnawave](https://img.shields.io/badge/Remnawave-3.4.3-6E56CF)
+![tests](https://img.shields.io/badge/tests-969_passing-brightgreen)
 
 <img src="docs/screenshots/topology.png" width="900" alt="Топология трафика графом: сквады, три inbound'а, пять правил маршрутизации, балансер с обсерваторией и пять outbound'ов, соединённые цветными кабелями" />
 
@@ -31,7 +31,9 @@
 > [!NOTE]
 > Редактор работает и с панелью 2.8.x, и с 3.x: используемые им ручки `config-profiles`,
 > `internal-squads` и `nodes` мажор не менял. Единственное расхождение — ответ на удаление
-> профиля (`204` против `200`), и оно обработано.
+> профиля (`204` против `200`), и оно обработано. Совместимость проверена на живой панели
+> **3.4.3**: чтение, сохранение с оптимистической блокировкой и конфликт `409` — без правок.
+> Теги профилей и сквадов (3.4.0) редактор не использует и не теряет.
 
 ---
 

--- a/backend/src/remnawave/client.ts
+++ b/backend/src/remnawave/client.ts
@@ -33,6 +33,18 @@ export function hintForNetworkError(baseUrl: string, cause: string): string | un
 }
 
 /**
+ * Токен панели живёт 30 дней, после чего она отвечает 401 на всё подряд. Отдать
+ * этот статус браузеру как есть нельзя: фронтенд трактует любой 401 как «сессия
+ * редактора истекла» и уводит на /login, где вход ничего не чинит — получается
+ * петля без единого намёка на настоящую причину. Поэтому 401/403 от панели
+ * становятся 502: сломан вышестоящий сервис, а не сессия пользователя.
+ */
+export const PANEL_TOKEN_HINT =
+  'Панель не приняла REMNAWAVE_TOKEN: срок его действия истёк (токен выдаётся на 30 дней) ' +
+  'либо он отозван. Выпустите новый API-токен в панели и пропишите его в .env, ' +
+  'затем перезапустите редактор.'
+
+/**
  * Разворачивает цепочку `cause`. `fetch` в Node на любую сетевую беду отвечает
  * одинаковым `TypeError: fetch failed`, а настоящая причина (ECONNREFUSED,
  * EAI_AGAIN, обрыв TLS) лежит глубже. Без разворота диагностика упирается в
@@ -115,6 +127,9 @@ export class RemnawaveClient implements RemnawavePort {
     }
     if (!res.ok) {
       const message = describePanelError(json) ?? `Панель ответила ${res.status}`
+      if (res.status === 401 || res.status === 403) {
+        throw new RemnawaveError(502, 'Панель Remnawave отклонила токен', message, PANEL_TOKEN_HINT)
+      }
       throw new RemnawaveError(res.status, message, json ?? text)
     }
     return json as T

--- a/backend/src/remnawave/token.ts
+++ b/backend/src/remnawave/token.ts
@@ -1,0 +1,71 @@
+/**
+ * Панель выдаёт API-токен на 30 дней и никак не напоминает об истечении: в день
+ * X она просто начинает отвечать 401 на всё. Редактор об этом скажет по-русски
+ * (см. PANEL_TOKEN_HINT), но уже постфактум — а предупредить лучше заранее.
+ *
+ * Срок лежит в claim `exp` самого токена, читать панель для этого не нужно.
+ * Подпись мы не проверяем и не можем: секрет HS256 знает только панель. Нам и
+ * незачем — токен пришёл из нашего же `.env`, вопрос стоит не «подлинный ли он»,
+ * а «когда протухнет». Испорченный `exp` поэтому не ошибка конфигурации, а
+ * просто «срок неизвестен».
+ */
+
+/** За сколько дней до истечения начинаем предупреждать. */
+export const EXPIRY_WARN_DAYS = 7
+
+export interface TokenStatus {
+  /** ISO-время истечения; null — срок прочитать не удалось */
+  expiresAt: string | null
+  /** Целых суток до истечения; отрицательное — просрочен; null — срок неизвестен */
+  daysLeft: number | null
+  expired: boolean
+  /** Пора выпускать новый: истёк или до истечения меньше EXPIRY_WARN_DAYS */
+  expiringSoon: boolean
+}
+
+const UNKNOWN: TokenStatus = {
+  expiresAt: null,
+  daysLeft: null,
+  expired: false,
+  expiringSoon: false,
+}
+
+/** `exp` в JWT — секунды с эпохи (RFC 7519), а не миллисекунды. */
+function readExpSeconds(token: string): number | undefined {
+  const payload = token.split('.')[1]
+  if (payload === undefined || payload === '') return undefined
+  let claims: unknown
+  try {
+    claims = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'))
+  } catch {
+    return undefined
+  }
+  if (typeof claims !== 'object' || claims === null || Array.isArray(claims)) return undefined
+  const exp = (claims as { exp?: unknown }).exp
+  return typeof exp === 'number' && Number.isFinite(exp) ? exp : undefined
+}
+
+export function describeToken(token: string, now: Date = new Date()): TokenStatus {
+  const exp = readExpSeconds(token)
+  if (exp === undefined) return UNKNOWN
+
+  const expiresAt = new Date(exp * 1000)
+  // Округляем вниз: «остался 1 день» честнее, чем «2», когда до конца 25 часов.
+  const daysLeft = Math.floor((expiresAt.getTime() - now.getTime()) / 86_400_000)
+  const expired = expiresAt.getTime() <= now.getTime()
+  return {
+    expiresAt: expiresAt.toISOString(),
+    daysLeft,
+    expired,
+    expiringSoon: expired || daysLeft <= EXPIRY_WARN_DAYS,
+  }
+}
+
+/** Строка для лога на старте; undefined — предупреждать не о чем. */
+export function describeTokenWarning(status: TokenStatus): string | undefined {
+  if (!status.expiringSoon) return undefined
+  if (status.expired) {
+    return `API-токен панели истёк ${status.expiresAt}. Панель будет отвечать 401 на все запросы — выпустите новый токен и обновите REMNAWAVE_TOKEN.`
+  }
+  return `API-токен панели истекает ${status.expiresAt} (осталось дней: ${status.daysLeft}). Выпустите новый токен заранее.`
+}

--- a/backend/src/remnawave/types.ts
+++ b/backend/src/remnawave/types.ts
@@ -23,6 +23,8 @@ export interface ConfigProfile {
   uuid: string
   viewPosition: number
   name: string
+  /** Панель 3.4.0+; редактор их не использует, но и не теряет: PATCH шлёт только name/config */
+  tags?: string[]
   config: unknown
   inbounds: PanelInbound[]
   nodes: PanelNodeRef[]

--- a/backend/src/routes/panel.ts
+++ b/backend/src/routes/panel.ts
@@ -1,6 +1,11 @@
 import type { FastifyPluginAsync } from 'fastify'
+import type { AppConfig } from '../config.js'
+import { describeToken } from '../remnawave/token.js'
 
-export const panelRoutes: FastifyPluginAsync = async (app) => {
+export const panelRoutes: FastifyPluginAsync<{ config: AppConfig }> = async (app, opts) => {
   app.get('/api/nodes', async () => ({ nodes: await app.remnawave.getNodes() }))
   app.get('/api/squads', async () => ({ squads: await app.remnawave.getSquads() }))
+
+  // Только срок: сам токен и его claims (uuid оператора) наружу не уходят.
+  app.get('/api/panel/token', async () => describeToken(opts.config.remnawaveToken))
 }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -8,6 +8,7 @@ import type { AppConfig } from './config.js'
 import { authRoutes } from './auth/routes.js'
 import { registerAuthGuard } from './auth/guard.js'
 import { RemnawaveClient, RemnawaveError } from './remnawave/client.js'
+import { describeToken, describeTokenWarning } from './remnawave/token.js'
 import type { RemnawavePort } from './remnawave/types.js'
 import { profileRoutes } from './routes/profiles.js'
 import { panelRoutes } from './routes/panel.js'
@@ -91,13 +92,18 @@ export async function buildServer(
     return reply.status(status).send({ message: err.message || 'Внутренняя ошибка' })
   })
 
+  // Срок токена панели виден из него самого — говорим о нём на старте, пока он
+  // ещё действует: постфактум оператор увидит только 401 на каждом запросе.
+  const tokenWarning = describeTokenWarning(describeToken(config.remnawaveToken))
+  if (tokenWarning !== undefined) app.log.warn(tokenWarning)
+
   registerAuthGuard(app, config.sessionTtlSeconds)
 
   app.get('/health', async () => ({ status: 'ok' }))
 
   await app.register(authRoutes, { config })
   await app.register(profileRoutes)
-  await app.register(panelRoutes)
+  await app.register(panelRoutes, { config })
   await app.register(backupRoutes)
   await app.register(toolsRoutes, {
     probeReality: deps.probeReality,

--- a/backend/test/panel-token.test.ts
+++ b/backend/test/panel-token.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+import { buildServer } from '../src/server.js'
+import { describeToken, describeTokenWarning, EXPIRY_WARN_DAYS } from '../src/remnawave/token.js'
+import { loginCookie, makeTestConfig } from './helpers.js'
+import { makeStubRemnawave } from './stub-remnawave.js'
+
+const NOW = new Date('2026-09-02T18:00:00.000Z')
+
+/** Панель подписывает токен HS256, но подпись нам не нужна и проверить её нечем:
+ *  секрет знает только панель. Читаем полезную нагрузку как есть. */
+function makeToken(payload: Record<string, unknown>): string {
+  const part = (o: unknown) => Buffer.from(JSON.stringify(o)).toString('base64url')
+  return `${part({ alg: 'HS256', typ: 'JWT' })}.${part(payload)}.подпись`
+}
+
+const inDays = (days: number) => Math.floor(NOW.getTime() / 1000) + days * 86_400
+
+describe('describeToken', () => {
+  it('считает остаток дней у действующего токена', () => {
+    const status = describeToken(makeToken({ role: 'API', exp: inDays(30) }), NOW)
+    expect(status.expiresAt).toBe('2026-10-02T18:00:00.000Z')
+    expect(status.daysLeft).toBe(30)
+    expect(status.expired).toBe(false)
+    expect(status.expiringSoon).toBe(false)
+  })
+
+  it('поднимает флаг за неделю до истечения', () => {
+    const status = describeToken(makeToken({ exp: inDays(EXPIRY_WARN_DAYS) }), NOW)
+    expect(status.expiringSoon).toBe(true)
+    expect(status.expired).toBe(false)
+  })
+
+  it('распознаёт истёкший токен', () => {
+    const status = describeToken(makeToken({ exp: inDays(-1) }), NOW)
+    expect(status.expired).toBe(true)
+    expect(status.expiringSoon).toBe(true)
+    expect(status.daysLeft).toBe(-1)
+  })
+
+  // Формат токена — дело панели, а не наш контракт: она вправе выдать что угодно.
+  // Не разобрали срок — молчим, а не пугаем оператора ложной тревогой.
+  it('молчит, когда срок прочитать нечем', () => {
+    for (const token of [
+      'не-jwt-вовсе',
+      'два.сегмента',
+      `${Buffer.from('{}').toString('base64url')}.не-base64!!.sig`,
+      makeToken({ role: 'API' }),
+      makeToken({ exp: 'завтра' }),
+    ]) {
+      const status = describeToken(token, NOW)
+      expect(status.expiresAt).toBeNull()
+      expect(status.daysLeft).toBeNull()
+      expect(status.expired).toBe(false)
+      expect(status.expiringSoon).toBe(false)
+    }
+  })
+
+  it('не роняет разбор на полезной нагрузке, которая не объект', () => {
+    expect(describeToken(makeToken([1, 2] as never), NOW).expiresAt).toBeNull()
+    const notJson = `x.${Buffer.from('просто текст').toString('base64url')}.y`
+    expect(describeToken(notJson, NOW).expiresAt).toBeNull()
+  })
+})
+
+describe('describeTokenWarning', () => {
+  it('молчит, пока до истечения далеко или срок неизвестен', () => {
+    expect(describeTokenWarning(describeToken(makeToken({ exp: inDays(30) }), NOW))).toBeUndefined()
+    expect(describeTokenWarning(describeToken('не-jwt', NOW))).toBeUndefined()
+  })
+
+  it('предупреждает заранее и отдельно — про уже истёкший', () => {
+    const soon = describeTokenWarning(describeToken(makeToken({ exp: inDays(3) }), NOW))
+    expect(soon).toContain('истекает')
+    expect(soon).toContain('осталось дней: 3')
+
+    const dead = describeTokenWarning(describeToken(makeToken({ exp: inDays(-5) }), NOW))
+    expect(dead).toContain('истёк')
+    expect(dead).toContain('REMNAWAVE_TOKEN')
+  })
+})
+
+describe('GET /api/panel/token', () => {
+  it('отдаёт срок действия токена, не раскрывая сам токен', async () => {
+    const config = makeTestConfig({ remnawaveToken: makeToken({ uuid: 'ff5f', exp: inDays(30) }) })
+    const app = await buildServer(config, { remnawave: makeStubRemnawave() })
+    const cookie = await loginCookie(app)
+
+    const res = await app.inject({ method: 'GET', url: '/api/panel/token', headers: { cookie } })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body).toEqual({
+      expiresAt: expect.any(String),
+      daysLeft: expect.any(Number),
+      expired: false,
+      expiringSoon: false,
+    })
+    expect(JSON.stringify(body)).not.toContain('ff5f')
+    await app.close()
+  })
+
+  it('закрыт гардом, как и остальные /api/*', async () => {
+    const app = await buildServer(makeTestConfig(), { remnawave: makeStubRemnawave() })
+    const res = await app.inject({ method: 'GET', url: '/api/panel/token' })
+    expect(res.statusCode).toBe(401)
+    await app.close()
+  })
+})

--- a/backend/test/remnawave-client.test.ts
+++ b/backend/test/remnawave-client.test.ts
@@ -133,6 +133,24 @@ describe('RemnawaveClient', () => {
     expect(err.message).toBe('Панель Remnawave отклонила токен')
   })
 
+  // Панель растёт: 3.4.0 добавила профилям tags, дальше добавит что-то ещё.
+  // Мы её ответы не валидируем намеренно — новые поля должны доезжать целыми,
+  // иначе каждый минор панели требовал бы релиза редактора.
+  it('новые поля панели проходят насквозь, а не теряются', async () => {
+    const client = new RemnawaveClient({
+      baseUrl: 'http://panel.test',
+      token: 't',
+      fetchImpl: fakeFetch(() => ({
+        status: 200,
+        body: { response: { ...profile, tags: ['prod'], полеИзБудущего: 42 } },
+      })),
+    })
+    const got = (await client.getProfile(profile.uuid)) as unknown as Record<string, unknown>
+    expect(got.tags).toEqual(['prod'])
+    expect(got['полеИзБудущего']).toBe(42)
+    expect(got.config).toEqual(profile.config)
+  })
+
   it('сетевая ошибка превращается в RemnawaveError 502 по-русски', async () => {
     const client = new RemnawaveClient({
       baseUrl: 'http://panel.test',

--- a/backend/test/remnawave-client.test.ts
+++ b/backend/test/remnawave-client.test.ts
@@ -106,6 +106,33 @@ describe('RemnawaveClient', () => {
     expect(err.message).toBe('Config profile not found')
   })
 
+  // 401/403 от панели нельзя пропускать наружу как есть: тот же статус фронтенд
+  // трактует как «сессия редактора истекла» и уводит на /login, где вход ничего
+  // не чинит. Причина вышестоящая — значит 502, как и для недоступной панели.
+  it('401 от панели превращается в 502 с подсказкой про токен', async () => {
+    const client = new RemnawaveClient({
+      baseUrl: 'http://panel.test',
+      token: 'протухший',
+      fetchImpl: fakeFetch(() => ({ status: 401, body: { message: 'Unauthorized' } })),
+    })
+    const err = await client.listProfiles().catch((e) => e)
+    expect(err).toBeInstanceOf(RemnawaveError)
+    expect(err.status).toBe(502)
+    expect(err.message).toBe('Панель Remnawave отклонила токен')
+    expect(err.hint).toMatch(/REMNAWAVE_TOKEN/)
+  })
+
+  it('403 от панели обрабатывается так же, как 401', async () => {
+    const client = new RemnawaveClient({
+      baseUrl: 'http://panel.test',
+      token: 'без прав',
+      fetchImpl: fakeFetch(() => ({ status: 403, body: { message: 'Forbidden' } })),
+    })
+    const err = await client.getNodes().catch((e) => e)
+    expect(err.status).toBe(502)
+    expect(err.message).toBe('Панель Remnawave отклонила токен')
+  })
+
   it('сетевая ошибка превращается в RemnawaveError 502 по-русски', async () => {
     const client = new RemnawaveClient({
       baseUrl: 'http://panel.test',

--- a/backend/test/stub-remnawave.ts
+++ b/backend/test/stub-remnawave.ts
@@ -7,6 +7,8 @@ export function makeProfile(overrides: Partial<ConfigProfile> = {}): ConfigProfi
     uuid: randomUUID(),
     viewPosition: 0,
     name: 'Test Profile',
+    // Панель 3.4.0 добавила профилям теги — держим стаб похожим на живой ответ
+    tags: [],
     config: { inbounds: [], outbounds: [] },
     inbounds: [],
     nodes: [],

--- a/frontend/e2e/mocks.ts
+++ b/frontend/e2e/mocks.ts
@@ -37,6 +37,10 @@ export const PROFILE = {
 export async function mockApi(page: Page) {
   await page.route('**/api/auth/me', (r) => r.fulfill({ json: { authenticated: true } }))
   await page.route('**/api/squads', (r) => r.fulfill({ json: { squads: [] } }))
+  // Срок токена панели: «неизвестен» — статус-бар при этом молчит
+  await page.route('**/api/panel/token', (r) =>
+    r.fulfill({ json: { expiresAt: null, daysLeft: null, expired: false, expiringSoon: false } }),
+  )
   // Обработчики просмотра идут раньше общего '**/api/geo': порядок здесь важен,
   // ранний маршрут Playwright перехватывает запрос первым
   await page.route('**/api/geo/geosite/categories', (r) =>

--- a/frontend/src/features/editor/EditorPage.tsx
+++ b/frontend/src/features/editor/EditorPage.tsx
@@ -8,6 +8,7 @@ import {
   useGeoMatch,
   useSaveProfile,
   useSquads,
+  usePanelToken,
   type Profile,
   type ProfileInboundDetail,
   type SquadInfo,
@@ -52,6 +53,7 @@ import { canRedo, canUndo, useHistoryStore } from './historyStore'
 import { VersionsDialog } from './VersionsDialog'
 import { ConfigSettingsDialog } from './ConfigSettingsDialog'
 import { IssueList } from './IssueList'
+import { PanelTokenNotice } from './PanelTokenNotice'
 import { JsonView } from './JsonView'
 import { ShortcutsDialog } from './ShortcutsDialog'
 import { SaveDialog } from './SaveDialog'
@@ -199,6 +201,7 @@ function EditorInner({ profile }: { profile: Profile }) {
   const [focus, setFocus] = useState<{ nodeId: string; nonce: number } | null>(null)
   const focusNonce = useRef(0)
   const squads = useSquads()
+  const panelToken = usePanelToken()
   const panelInbounds = useProfileInbounds(profile.uuid)
   const ctx = useMemo(
     () => toGraphContext(squads.data, panelInbounds.data),
@@ -545,6 +548,7 @@ function EditorInner({ profile }: { profile: Profile }) {
             </button>
           )}
           <span className="spacer" />
+          <PanelTokenNotice status={panelToken.data} />
           {saveError && <span className="field-error">{saveError}</span>}
         </div>
         {issuesOpen && validation.issues.length > 0 && (

--- a/frontend/src/features/editor/PanelTokenNotice.tsx
+++ b/frontend/src/features/editor/PanelTokenNotice.tsx
@@ -1,0 +1,48 @@
+import type { PanelTokenStatus } from '../../shared/api/types'
+
+/**
+ * Токен панели выдаётся на 30 дней, и панель никак не напоминает об истечении:
+ * в день X она просто начинает отвечать 401 на всё. Бэкенд предупреждает об
+ * этом в логах, но оператор смотрит не в логи, а сюда.
+ */
+export function PanelTokenNotice({ status }: { status?: PanelTokenStatus }) {
+  if (status === undefined || !status.expiringSoon || status.daysLeft === null) return null
+
+  const title =
+    status.expiresAt === null
+      ? undefined
+      : `Срок действия REMNAWAVE_TOKEN: ${new Date(status.expiresAt).toLocaleDateString('ru-RU')}`
+
+  return (
+    <span
+      role="status"
+      className={status.expired ? 'field-error' : 'field-warning'}
+      title={title}
+    >
+      {status.expired
+        ? 'API-токен панели истёк — выпустите новый и обновите REMNAWAVE_TOKEN'
+        : `API-токен панели истекает ${humanizeDays(status.daysLeft)}`}
+    </span>
+  )
+}
+
+function humanizeDays(days: number): string {
+  if (days <= 0) return 'сегодня'
+  return `через ${days} ${pluralizeDays(days)}`
+}
+
+/** 1 день, 2–4 дня, 5–20 дней; десятки и сотни считаются по последним цифрам. */
+function pluralizeDays(days: number): string {
+  const tail = days % 100
+  if (tail >= 11 && tail <= 14) return 'дней'
+  switch (days % 10) {
+    case 1:
+      return 'день'
+    case 2:
+    case 3:
+    case 4:
+      return 'дня'
+    default:
+      return 'дней'
+  }
+}

--- a/frontend/src/shared/api/hooks.ts
+++ b/frontend/src/shared/api/hooks.ts
@@ -7,6 +7,7 @@ import type {
   GeoKind,
   GeoMatchAnswer,
   GeoStatus,
+  PanelTokenStatus,
   Profile,
   ProfileInboundDetail,
   RealityProbeResult,
@@ -98,6 +99,15 @@ export function useSquads() {
     queryKey: ['squads'],
     queryFn: () => apiFetch<{ squads: SquadInfo[] }>('/api/squads').then((r) => r.squads),
     staleTime: 60_000,
+  })
+}
+
+/** Срок токена панели меняется раз в месяц — часто спрашивать нечего. */
+export function usePanelToken() {
+  return useQuery({
+    queryKey: ['panel', 'token'],
+    queryFn: () => apiFetch<PanelTokenStatus>('/api/panel/token'),
+    staleTime: 60 * 60_000,
   })
 }
 

--- a/frontend/src/shared/api/types.ts
+++ b/frontend/src/shared/api/types.ts
@@ -24,6 +24,14 @@ export interface Profile {
   updatedAt: string
 }
 
+/** Срок действия REMNAWAVE_TOKEN; null'ы — панель выдала токен, чей срок не разобрать */
+export interface PanelTokenStatus {
+  expiresAt: string | null
+  daysLeft: number | null
+  expired: boolean
+  expiringSoon: boolean
+}
+
 export interface SquadInfo {
   uuid: string
   name: string

--- a/frontend/test/panel-token-notice.test.tsx
+++ b/frontend/test/panel-token-notice.test.tsx
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { PanelTokenNotice } from '../src/features/editor/PanelTokenNotice'
+import type { PanelTokenStatus } from '../src/shared/api/types'
+
+const status = (over: Partial<PanelTokenStatus>): PanelTokenStatus => ({
+  expiresAt: '2026-10-02T18:00:00.000Z',
+  daysLeft: 30,
+  expired: false,
+  expiringSoon: false,
+  ...over,
+})
+
+describe('PanelTokenNotice', () => {
+  it('молчит, пока до истечения далеко', () => {
+    const { container } = render(<PanelTokenNotice status={status({})} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  // Срок неизвестен (токен панели — не JWT) — это не повод пугать оператора.
+  it('молчит, когда статуса нет или срок не разобран', () => {
+    const { container: a } = render(<PanelTokenNotice status={undefined} />)
+    expect(a).toBeEmptyDOMElement()
+    const { container: b } = render(
+      <PanelTokenNotice status={status({ expiresAt: null, daysLeft: null })} />,
+    )
+    expect(b).toBeEmptyDOMElement()
+  })
+
+  it('предупреждает за неделю до истечения', () => {
+    render(<PanelTokenNotice status={status({ daysLeft: 5, expiringSoon: true })} />)
+    expect(screen.getByText(/токен панели истекает через 5 дней/i)).toBeInTheDocument()
+  })
+
+  it('склоняет остаток дней по-русски', () => {
+    const text = (daysLeft: number) => {
+      const { unmount } = render(
+        <PanelTokenNotice status={status({ daysLeft, expiringSoon: true })} />,
+      )
+      const found = screen.getByRole('status').textContent ?? ''
+      unmount()
+      return found
+    }
+    expect(text(1)).toContain('через 1 день')
+    expect(text(2)).toContain('через 2 дня')
+    expect(text(5)).toContain('через 5 дней')
+    expect(text(0)).toContain('сегодня')
+  })
+
+  it('про истёкший токен говорит прямо и называет, что чинить', () => {
+    render(<PanelTokenNotice status={status({ daysLeft: -3, expired: true, expiringSoon: true })} />)
+    const notice = screen.getByRole('status')
+    expect(notice).toHaveTextContent(/истёк/i)
+    expect(notice).toHaveTextContent(/REMNAWAVE_TOKEN/)
+  })
+
+  it('точную дату кладёт в подсказку, а не в строку статус-бара', () => {
+    render(<PanelTokenNotice status={status({ daysLeft: 2, expiringSoon: true })} />)
+    expect(screen.getByRole('status')).toHaveAttribute('title', expect.stringContaining('02.10.2026'))
+  })
+})


### PR DESCRIPTION
## Зачем

Проект был заявлен совместимым с панелью 3.2.1, актуальная — 3.4.3. Проверил на живой панели и поправил найденное.

## Совместимость с 3.4.3 — правок не потребовалось

Прогнал все девять ручек, которыми пользуется редактор, против живой панели 3.4.3:

- чтение: `config-profiles` (список и по uuid), `inbounds`, `computed-config`, `nodes`, `internal-squads` — 200, все поля на месте;
- запись: создание профиля, `PATCH` с актуальным `expectedUpdatedAt`, конфликт `409` на устаревшем, бэкап перед обновлением, удаление — весь путь работает.

Разбор changelog'ов 3.2.1 → 3.4.3: единственное ломающее изменение API (3.4.0, `excludedInternalSquads` → `internalSquads`) относится к объекту Хоста, который редактор не читает. `cipherSuites` из 3.2.3 уже поддержан. Теги профилей и сквадов (3.4.0) — аддитивны.

## Исправлено: 401 панели выдавал себя за истёкшую сессию

Токен панели живёт 30 дней. После истечения панель отвечает `401` на всё, этот статус доезжал до браузера как есть, а фронтенд трактует любой `401` как «сессия редактора истекла» и уводит на `/login`. Вход там ничего не чинил — получалась петля, а настоящая причина была видна только в логах бэкенда.

Теперь `401`/`403` от панели становятся `502` с подсказкой выпустить новый токен: сломан вышестоящий сервис, а не сессия пользователя.

## Добавлено: предупреждение об истечении заранее

Срок лежит в claim `exp` самого токена — читаем его, не обращаясь к панели.

- предупреждение в лог на старте, когда до конца меньше недели;
- `GET /api/panel/token` отдаёт **только** срок: сам токен и его claims наружу не уходят;
- статус-бар редактора показывает остаток («истекает через 5 дней»), для истёкшего — что именно чинить.

Не разобрали срок (панель вправе выдать не-JWT) — молчим, а не пугаем ложной тревогой.

## Проверка

- `npm test` — backend 245, frontend 724 (было 235/718);
- `npm run e2e -w frontend` — 51 passed;
- `npm run typecheck` обоих workspace и `npm run build` — чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GY78ENudgznnwMXNkiac4s
